### PR TITLE
fix: change offset type to Duration

### DIFF
--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -76,7 +76,7 @@ pub enum Expr {
     SubqueryExpr {
         expr: Box<Expr>,
         range: Duration,
-        offset: Instant,
+        offset: Duration,
         timestamp: Option<i64>,
         start_or_end: TokenType, // Set when @ is used with start() or end()
         step: Duration,
@@ -96,7 +96,7 @@ pub enum Expr {
         name: Option<String>,
         // offset is the actual offset that was set in the query.
         // This never changes.
-        offset: Option<Instant>,
+        offset: Option<Duration>,
         start_or_end: Option<TokenType>, // Set when @ is used with start() or end()
         label_matchers: Matchers,
     },


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

According to the go version, the field `offset` is with type `Duration` rather than `Instant`:
```go
// SubqueryExpr represents a subquery.
type SubqueryExpr struct {
	Expr  Expr
	Range time.Duration
	// OriginalOffset is the actual offset that was set in the query.
	// This never changes.
	OriginalOffset time.Duration
	// Offset is the offset used during the query execution
	// which is calculated using the original offset, at modifier time,
	// eval time, and subquery offsets in the AST tree.
	Offset     time.Duration
	Timestamp  *int64
	StartOrEnd ItemType // Set when @ is used with start() or end()
	Step       time.Duration

	EndPos Pos
}
```
and
```go
// VectorSelector represents a Vector selection.
type VectorSelector struct {
	Name string
	// OriginalOffset is the actual offset that was set in the query.
	// This never changes.
	OriginalOffset time.Duration
	// Offset is the offset used during the query execution
	// which is calculated using the original offset, at modifier time,
	// eval time, and subquery offsets in the AST tree.
	Offset        time.Duration
	Timestamp     *int64
	StartOrEnd    ItemType // Set when @ is used with start() or end()
	LabelMatchers []*labels.Matcher

	// The unexpanded seriesSet populated at query preparation time.
	UnexpandedSeriesSet storage.SeriesSet
	Series              []storage.Series

	PosRange PositionRange
}
```