### PR TITLE
feat: replace Instant with SystemTime

### DIFF
--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -15,7 +15,7 @@
 #![allow(dead_code)]
 use lrpar::Span;
 use std::fmt::{self, Display};
-use std::time::{Duration, Instant};
+use std::time::{Duration, SystemTime};
 
 use crate::label::Matchers;
 use crate::parser::{Function, TokenType};
@@ -27,8 +27,8 @@ pub struct EvalStmt {
 
     // The time boundaries for the evaluation. If start equals end an instant
     // is evaluated.
-    start: Instant,
-    end: Instant,
+    start: SystemTime,
+    end: SystemTime,
     // Time between two evaluated instants for the range [start:end].
     interval: Duration,
     // Lookback delta to use for this evaluation.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -20,7 +20,7 @@ pub mod production;
 pub mod token;
 pub mod value;
 
-pub use ast::Expr;
+pub use ast::{EvalStmt, Expr};
 pub use function::{get_function, Function};
 pub use lex::{lexer, LexemeType};
 pub use parse::parse;


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

This patch
- Public `EvalStmt`
- Change `Instant` to `SystemTime`. Because the constant `UNIX_EPOCH` is with type `SystemTime`. To convert to timestamp we need to subtract (`duration_since`) `UNIC_EPOCH`.