### PR TITLE
feat: derive Clone for Expr

### DIFF
--- a/src/label/matcher.rs
+++ b/src/label/matcher.rs
@@ -15,7 +15,7 @@
 use crate::parser::token::{Token, T_EQL, T_EQL_REGEX, T_NEQ, T_NEQ_REGEX};
 use regex::Regex;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum MatchOp {
     Equal,
     NotEqual,
@@ -24,7 +24,7 @@ pub enum MatchOp {
 }
 
 // Matcher models the matching of a label.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Matcher {
     op: MatchOp,
     name: String,
@@ -51,7 +51,7 @@ impl Matcher {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Matchers {
     matchers: Vec<Matcher>,
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -35,7 +35,7 @@ pub struct EvalStmt {
     lookback_delta: Duration,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Expr {
     /// AggregateExpr represents an aggregation operation on a Vector.
     AggregateExpr {
@@ -136,7 +136,7 @@ impl Expr {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum VectorMatchCardinality {
     OneToOne,
     ManyToOne,
@@ -157,7 +157,7 @@ impl Display for VectorMatchCardinality {
 
 // VectorMatching describes how elements from two Vectors in a binary
 // operation are supposed to be matched.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct VectorMatching {
     // The cardinality of the two Vectors.
     card: VectorMatchCardinality,

--- a/src/parser/function.rs
+++ b/src/parser/function.rs
@@ -18,7 +18,7 @@ use lazy_static::lazy_static;
 
 use crate::parser::ValueType;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Function {
     pub name: &'static str,
     pub arg_types: Vec<ValueType>,


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

Derive `Clone` attribute for `Expr`. This can make it easy to use on planning.