### PR TITLE
feat: derive Debug and Clone for EvalStmt

### DIFF
--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -22,6 +22,7 @@ use crate::parser::{Function, TokenType};
 
 /// EvalStmt holds an expression and information on the range it should
 /// be evaluated on.
+#[derive(Debug, Clone)]
 pub struct EvalStmt {
     pub expr: Expr, // Expression to be evaluated.
 


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

Derive `Debug` and `Clone` for `EvalStmt`. I also tried to derive `PartialEq` and `Eq`, but `f64` is not full-ordered, and `Regex` cannot be compared. 