### PR TITLE
feat(ast): impl PartialEq, Eq for Expr

### DIFF
--- a/src/label/mod.rs
+++ b/src/label/mod.rs
@@ -14,7 +14,7 @@
 
 mod matcher;
 
-pub use matcher::{new_matcher, MatchOp, Matcher, Matchers};
+pub use matcher::{MatchOp, Matcher, Matchers};
 use std::collections::HashSet;
 
 // Well-known label names used by Prometheus components.

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -19,22 +19,23 @@ use crate::parser::{Function, FunctionArgs, Token, TokenType};
 use std::collections::HashSet;
 use std::time::{Duration, SystemTime};
 
+type Label = String;
+
 /// Matching Modifier, for VectorMatching of binary expr.
 /// Label lists provided to matching keywords will determine how vectors are combined.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VectorMatchModifier {
-    On(HashSet<String>),
-    Ignoring(HashSet<String>),
+    On(HashSet<Label>),
+    Ignoring(HashSet<Label>),
 }
 
+/// The label list provided with the group_left or group_right modifier contains
+/// additional labels from the "one"-side to be included in the result metrics.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VectorMatchCardinality {
     OneToOne,
-
-    /// The label list provided with the group_left or group_right modifier contains
-    /// additional labels from the "one"-side to be included in the result metrics.
-    ManyToOne(HashSet<String>),
-    OneToMany(HashSet<String>),
+    ManyToOne(HashSet<Label>),
+    OneToMany(HashSet<Label>),
     // ManyToMany, // useless so far
 }
 
@@ -44,17 +45,22 @@ pub struct BinModifier {
     /// The matching behavior for the operation if both operands are Vectors.
     /// If they are not this field is None.
     pub card: VectorMatchCardinality,
+    /// on/ignoring on labels
     pub matching: VectorMatchModifier,
-
     /// If a comparison operator, return 0/1 rather than filtering.
     pub return_bool: bool,
 }
 
 /// Aggregation Modifier
+///
+/// `without` removes the listed labels from the result vector,
+/// while all other labels are preserved in the output.
+/// `by` does the opposite and drops labels that are not listed in the by clause,
+/// even if their label values are identical between all elements of the vector.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AggModifier {
-    By(HashSet<String>),
-    Without(HashSet<String>),
+    By(HashSet<Label>),
+    Without(HashSet<Label>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -67,6 +73,7 @@ pub enum Offset {
 pub enum AtModifier {
     Start,
     End,
+    /// at can be earlier than UNIX_EPOCH
     At(SystemTime),
 }
 

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -71,15 +71,26 @@ pub enum AtModifier {
     At(SystemTime),
 }
 
+impl TryFrom<TokenType> for AtModifier {
+    type Error = String;
+
+    fn try_from(id: TokenType) -> Result<Self, Self::Error> {
+        match id {
+            T_START => Ok(AtModifier::Start),
+            T_END => Ok(AtModifier::End),
+            _ => Err(format!(
+                "invalid @ modifier preprocessor '{}', START or END is valid.",
+                token::token_display(id)
+            )),
+        }
+    }
+}
+
 impl TryFrom<Token> for AtModifier {
     type Error = String;
 
     fn try_from(token: Token) -> Result<Self, Self::Error> {
-        match token.id() {
-            T_START => Ok(AtModifier::Start),
-            T_END => Ok(AtModifier::End),
-            _ => Err(format!("invalid at modifier preprocessor {}", token.val())),
-        }
+        AtModifier::try_from(token.id())
     }
 }
 

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -16,46 +16,45 @@
 use crate::label::Matchers;
 use crate::parser::token::{self, T_END, T_START};
 use crate::parser::{Function, FunctionArgs, Token, TokenType};
+use std::collections::HashSet;
 use std::time::{Duration, SystemTime};
 
-// TODO: better PartialEq, Eq ignoring Vec<String> orders
 /// Matching Modifier, for VectorMatching of binary expr.
 /// Label lists provided to matching keywords will determine how vectors are combined.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VectorMatchModifier {
-    On(Vec<String>),
-    Ignoring(Vec<String>),
+    On(HashSet<String>),
+    Ignoring(HashSet<String>),
 }
 
-// TODO: better PartialEq, Eq ignoring Vec<String> orders
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VectorMatchCardinality {
     OneToOne,
 
-    // The label list provided with the group_left or group_right modifier contains
-    // additional labels from the "one"-side to be included in the result metrics.
-    ManyToOne(Vec<String>),
-    OneToMany(Vec<String>),
+    /// The label list provided with the group_left or group_right modifier contains
+    /// additional labels from the "one"-side to be included in the result metrics.
+    ManyToOne(HashSet<String>),
+    OneToMany(HashSet<String>),
     // ManyToMany, // useless so far
 }
 
 /// Binary Expr Modifier
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BinModifier {
-    // The matching behavior for the operation if both operands are Vectors.
-    // If they are not this field is None.
+    /// The matching behavior for the operation if both operands are Vectors.
+    /// If they are not this field is None.
     pub card: VectorMatchCardinality,
     pub matching: VectorMatchModifier,
 
-    // If a comparison operator, return 0/1 rather than filtering.
+    /// If a comparison operator, return 0/1 rather than filtering.
     pub return_bool: bool,
 }
 
 /// Aggregation Modifier
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AggModifier {
-    By(Vec<String>),
-    Without(Vec<String>),
+    By(HashSet<String>),
+    Without(HashSet<String>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -125,15 +124,16 @@ impl TryFrom<f64> for AtModifier {
 /// be evaluated on.
 #[derive(Debug, Clone)]
 pub struct EvalStmt {
-    pub expr: Expr, // Expression to be evaluated.
+    /// Expression to be evaluated.
+    pub expr: Expr,
 
-    // The time boundaries for the evaluation. If start equals end an instant
-    // is evaluated.
+    /// The time boundaries for the evaluation. If start equals end an instant
+    /// is evaluated.
     pub start: SystemTime,
     pub end: SystemTime,
-    // Time between two evaluated instants for the range [start:end].
+    /// Time between two evaluated instants for the range [start:end].
     pub interval: Duration,
-    // Lookback delta to use for this evaluation.
+    /// Lookback delta to use for this evaluation.
     pub lookback_delta: Duration,
 }
 
@@ -144,9 +144,12 @@ pub struct EvalStmt {
 /// parameter is only required for count_values, quantile, topk and bottomk.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AggregateExpr {
-    pub op: TokenType,            // The used aggregation operation.
-    pub expr: Box<Expr>,          // The Vector expression over which is aggregated.
-    pub param: Option<Box<Expr>>, // Parameter used by some aggregators.
+    /// The used aggregation operation.
+    pub op: TokenType,
+    /// The Vector expression over which is aggregated.
+    pub expr: Box<Expr>,
+    /// Parameter used by some aggregators.
+    pub param: Option<Box<Expr>>,
     pub grouping: AggModifier,
 }
 
@@ -163,9 +166,12 @@ pub struct UnaryExpr {
 ///
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BinaryExpr {
-    pub op: TokenType,  // The operation of the expression.
-    pub lhs: Box<Expr>, // The operands on the left sides of the operator.
-    pub rhs: Box<Expr>, // The operands on the right sides of the operator.
+    /// The operation of the expression.
+    pub op: TokenType,
+    /// The operands on the left sides of the operator.
+    pub lhs: Box<Expr>,
+    /// The operands on the right sides of the operator.
+    pub rhs: Box<Expr>,
 
     pub matching: BinModifier,
 }
@@ -247,14 +253,19 @@ pub enum Expr {
     /// of operator precedence.
     Paren(ParenExpr),
 
+    /// SubqueryExpr represents a subquery.
     Subquery(SubqueryExpr),
 
+    /// NumberLiteral represents a number.
     NumberLiteral(NumberLiteral),
 
+    /// StringLiteral represents a string.
     StringLiteral(StringLiteral),
 
+    /// VectorSelector represents a Vector selection.
     VectorSelector(VectorSelector),
 
+    /// MatrixSelector represents a Matrix selection.
     MatrixSelector(MatrixSelector),
 
     /// Call represents a function call.

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -13,11 +13,102 @@
 // limitations under the License.
 
 #![allow(dead_code)]
-use std::fmt::{self, Display};
+use crate::label::Matchers;
+use crate::parser::token::{self, T_END, T_START};
+use crate::parser::{Function, FunctionArgs, Token, TokenType};
 use std::time::{Duration, SystemTime};
 
-use crate::label::Matchers;
-use crate::parser::{Function, TokenType};
+// TODO: better PartialEq, Eq ignoring Vec<String> orders
+/// Matching Modifier, for VectorMatching of binary expr.
+/// Label lists provided to matching keywords will determine how vectors are combined.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VectorMatchModifier {
+    On(Vec<String>),
+    Ignoring(Vec<String>),
+}
+
+// TODO: better PartialEq, Eq ignoring Vec<String> orders
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VectorMatchCardinality {
+    OneToOne,
+
+    // The label list provided with the group_left or group_right modifier contains
+    // additional labels from the "one"-side to be included in the result metrics.
+    ManyToOne(Vec<String>),
+    OneToMany(Vec<String>),
+    // ManyToMany, // useless so far
+}
+
+/// Binary Expr Modifier
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BinModifier {
+    // The matching behavior for the operation if both operands are Vectors.
+    // If they are not this field is None.
+    pub card: VectorMatchCardinality,
+    pub matching: VectorMatchModifier,
+
+    // If a comparison operator, return 0/1 rather than filtering.
+    pub return_bool: bool,
+}
+
+/// Aggregation Modifier
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AggModifier {
+    By(Vec<String>),
+    Without(Vec<String>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Offset {
+    Pos(Duration),
+    Neg(Duration),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AtModifier {
+    Start,
+    End,
+    At(SystemTime),
+}
+
+impl TryFrom<Token> for AtModifier {
+    type Error = String;
+
+    fn try_from(token: Token) -> Result<Self, Self::Error> {
+        match token.id() {
+            T_START => Ok(AtModifier::Start),
+            T_END => Ok(AtModifier::End),
+            _ => Err(format!("invalid at modifier preprocessor {}", token.val())),
+        }
+    }
+}
+
+impl TryFrom<f64> for AtModifier {
+    type Error = String;
+
+    fn try_from(secs: f64) -> Result<Self, Self::Error> {
+        let err = Err(format!("timestamp out of bounds for @ modifier: {secs}"));
+
+        if secs.is_nan() || secs.is_infinite() || secs >= f64::MAX || secs <= f64::MIN {
+            return err;
+        }
+        let milli = (secs * 1000f64).round().abs() as u64;
+
+        let duration = Duration::from_millis(milli);
+        let mut st = Some(SystemTime::UNIX_EPOCH);
+        if secs.is_sign_positive() {
+            st = SystemTime::UNIX_EPOCH.checked_add(duration);
+        }
+        if secs.is_sign_negative() {
+            st = SystemTime::UNIX_EPOCH.checked_sub(duration);
+        }
+
+        match st {
+            Some(st) => Ok(Self::At(st)),
+            None => err,
+        }
+    }
+}
 
 /// EvalStmt holds an expression and information on the range it should
 /// be evaluated on.
@@ -35,47 +126,52 @@ pub struct EvalStmt {
     pub lookback_delta: Duration,
 }
 
-#[derive(Debug, Clone)]
+/// <aggr-op> [without|by (<label list>)] ([parameter,] <vector expression>)
+/// or
+/// <aggr-op>([parameter,] <vector expression>) [without|by (<label list>)]
+///
+/// parameter is only required for count_values, quantile, topk and bottomk.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AggregateExpr {
-    pub op: TokenType,         // The used aggregation operation.
-    pub expr: Box<Expr>,       // The Vector expression over which is aggregated.
-    pub param: Box<Expr>,      // Parameter used by some aggregators.
-    pub grouping: Vec<String>, // The labels by which to group the Vector.
-    pub without: bool,         // Whether to drop the given labels rather than keep them.
+    pub op: TokenType,            // The used aggregation operation.
+    pub expr: Box<Expr>,          // The Vector expression over which is aggregated.
+    pub param: Option<Box<Expr>>, // Parameter used by some aggregators.
+    pub grouping: AggModifier,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnaryExpr {
     pub op: TokenType,
     pub expr: Box<Expr>,
 }
 
-#[derive(Debug, Clone)]
+/// <vector expr> <bin-op> ignoring(<label list>) group_left(<label list>) <vector expr>
+/// <vector expr> <bin-op> ignoring(<label list>) group_right(<label list>) <vector expr>
+/// <vector expr> <bin-op> on(<label list>) group_left(<label list>) <vector expr>
+/// <vector expr> <bin-op> on(<label list>) group_right(<label list>) <vector expr>
+///
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BinaryExpr {
     pub op: TokenType,  // The operation of the expression.
     pub lhs: Box<Expr>, // The operands on the left sides of the operator.
     pub rhs: Box<Expr>, // The operands on the right sides of the operator.
 
-    // The matching behavior for the operation if both operands are Vectors.
-    // If they are not this field is None.
-    pub matching: Option<VectorMatching>,
-
-    // If a comparison operator, return 0/1 rather than filtering.
-    pub return_bool: bool,
+    pub matching: BinModifier,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParenExpr {
     pub expr: Box<Expr>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SubqueryExpr {
     pub expr: Box<Expr>,
+    pub offset: Option<Offset>,
+
+    /// at modifier can be earlier than UNIX_EPOCH
+    pub at: Option<AtModifier>,
     pub range: Duration,
-    pub offset: Duration,
-    pub timestamp: Option<i64>,
-    pub start_or_end: TokenType, // Set when @ is used with start() or end()
     pub step: Duration,
 }
 
@@ -84,36 +180,47 @@ pub struct NumberLiteral {
     pub val: f64,
 }
 
-#[derive(Debug, Clone)]
+impl NumberLiteral {
+    pub fn new(val: f64) -> Self {
+        Self { val }
+    }
+}
+
+impl PartialEq for NumberLiteral {
+    fn eq(&self, other: &Self) -> bool {
+        self.val == other.val
+    }
+}
+
+impl Eq for NumberLiteral {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StringLiteral {
     pub val: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VectorSelector {
     pub name: Option<String>,
-    // offset is the actual offset that was set in the query.
-    // This never changes.
-    pub offset: Option<Duration>,
-    pub start_or_end: Option<TokenType>, // Set when @ is used with start() or end()
     pub label_matchers: Matchers,
+    pub offset: Option<Offset>,
+    /// at modifier can be earlier than UNIX_EPOCH
+    pub at: Option<AtModifier>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MatrixSelector {
-    // It is safe to assume that this is an VectorSelector
-    // if the parser hasn't returned an error.
-    pub vector_selector: Box<Expr>,
+    pub vector_selector: VectorSelector,
     pub range: Duration,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Call {
-    pub func: Function,       // The function that was called.
-    pub args: Vec<Box<Expr>>, // Arguments used in the call.
+    pub func: Function,
+    pub args: FunctionArgs,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Expr {
     /// Aggregate represents an aggregation operation on a Vector.
     Aggregate(AggregateExpr),
@@ -140,64 +247,246 @@ pub enum Expr {
     MatrixSelector(MatrixSelector),
 
     /// Call represents a function call.
-    // TODO: need more descriptions
     Call(Call),
 }
 
 impl Expr {
-    pub fn empty_vector_selector() -> Self {
-        let vs = VectorSelector {
-            name: None,
-            offset: None,
-            start_or_end: None,
-            label_matchers: Matchers::empty(),
-        };
-        Self::VectorSelector(vs)
-    }
-
-    pub fn new_vector_selector(name: Option<String>, matchers: Matchers) -> Self {
+    pub fn new_vector_selector(name: Option<String>, matchers: Matchers) -> Result<Self, String> {
         let vs = VectorSelector {
             name,
             offset: None,
-            start_or_end: None,
+            at: None,
             label_matchers: matchers,
         };
-        Self::VectorSelector(vs)
+        Ok(Self::VectorSelector(vs))
     }
-}
 
-#[derive(Debug, Clone, Copy)]
-pub enum VectorMatchCardinality {
-    OneToOne,
-    ManyToOne,
-    OneToMany,
-    ManyToMany,
-}
+    pub fn new_unary_expr(expr: Expr, op: &Token) -> Result<Self, String> {
+        let ue = match expr {
+            Expr::NumberLiteral(NumberLiteral { val }) => {
+                Expr::NumberLiteral(NumberLiteral { val: -val })
+            }
+            _ => Expr::Unary(UnaryExpr {
+                op: op.id(),
+                expr: Box::new(expr),
+            }),
+        };
+        Ok(ue)
+    }
 
-impl Display for VectorMatchCardinality {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            VectorMatchCardinality::OneToOne => write!(f, "one-to-one"),
-            VectorMatchCardinality::ManyToOne => write!(f, "many-to-one"),
-            VectorMatchCardinality::OneToMany => write!(f, "one-to-many"),
-            VectorMatchCardinality::ManyToMany => write!(f, "many-to-many"),
+    pub fn new_subquery_expr(expr: Expr, range: Duration, step: Duration) -> Result<Self, String> {
+        let se = Expr::Subquery(SubqueryExpr {
+            expr: Box::new(expr),
+            offset: None,
+            at: None,
+            range,
+            step,
+        });
+        Ok(se)
+    }
+
+    pub fn new_paren_expr(expr: Expr) -> Result<Self, String> {
+        let ex = Expr::Paren(ParenExpr {
+            expr: Box::new(expr),
+        });
+        Ok(ex)
+    }
+
+    pub fn new_number_literal(val: f64) -> Result<Self, String> {
+        Ok(Expr::NumberLiteral(NumberLiteral { val }))
+    }
+
+    pub fn new_string_literal(val: String) -> Result<Self, String> {
+        Ok(Expr::StringLiteral(StringLiteral { val }))
+    }
+
+    /// NOTE: @ and offset is not set here.
+    pub fn new_matrix_selector(expr: Expr, range: Duration) -> Result<Self, String> {
+        match expr {
+            Expr::VectorSelector(VectorSelector {
+                offset: Some(_), ..
+            }) => Err("no offset modifiers allowed before range".into()),
+            Expr::VectorSelector(VectorSelector { at: Some(_), .. }) => {
+                Err("no @ modifiers allowed before range".into())
+            }
+            Expr::VectorSelector(vs) => {
+                let ms = Expr::MatrixSelector(MatrixSelector {
+                    vector_selector: vs,
+                    range,
+                });
+                Ok(ms)
+            }
+            _ => Err("ranges only allowed for vector selectors".into()),
         }
     }
+
+    /// set at_modifier for specified Expr, but CAN ONLY be set once.
+    pub fn step_invariant_expr(self, at_modifier: AtModifier) -> Result<Self, String> {
+        let already_set_err = Err("@ <timestamp> may not be set multiple times".into());
+        match self {
+            Expr::VectorSelector(mut vs) => match vs.at {
+                None => {
+                    vs.at = Some(at_modifier);
+                    Ok(Expr::VectorSelector(vs))
+                }
+                Some(_) => already_set_err,
+            },
+            Expr::MatrixSelector(mut ms) => match ms.vector_selector.at {
+                None => {
+                    ms.vector_selector.at = Some(at_modifier);
+                    Ok(Expr::MatrixSelector(ms))
+                }
+                Some(_) => already_set_err,
+            },
+            Expr::Subquery(mut s) => match s.at {
+                None => {
+                    s.at = Some(at_modifier);
+                    Ok(Expr::Subquery(s))
+                }
+                Some(_) => already_set_err,
+            },
+            _ => {
+                Err("@ modifier must be preceded by an instant vector selector or range vector selector or a subquery".into())
+            }
+        }
+    }
+
+    /// set offset field for specified Expr, but CAN ONLY be set once.
+    pub fn offset_expr(self, offset: Offset) -> Result<Self, String> {
+        let already_set_err = Err("offset may not be set multiple times".into());
+        match self {
+            Expr::VectorSelector(mut vs) => match vs.at {
+                None => {
+                    vs.offset = Some(offset);
+                    Ok(Expr::VectorSelector(vs))
+                }
+                Some(_) => already_set_err,
+            },
+            Expr::MatrixSelector(mut ms) => match ms.vector_selector.at {
+                None => {
+                    ms.vector_selector.offset = Some(offset);
+                    Ok(Expr::MatrixSelector(ms))
+                }
+                Some(_) => already_set_err,
+            },
+            Expr::Subquery(mut s) => match s.at {
+                None => {
+                    s.offset = Some(offset);
+                    Ok(Expr::Subquery(s))
+                }
+                Some(_) => already_set_err,
+            },
+            _ => {
+                Err("offset modifier must be preceded by an instant vector selector or range vector selector or a subquery".into())
+            }
+        }
+    }
+
+    pub fn new_call(func: Function, args: FunctionArgs) -> Result<Expr, String> {
+        Ok(Expr::Call(Call { func, args }))
+    }
+
+    pub fn new_binary_expr(
+        lhs: Expr,
+        op: TokenType,
+        matching: BinModifier,
+        rhs: Expr,
+    ) -> Result<Expr, String> {
+        let ex = BinaryExpr {
+            op,
+            lhs: Box::new(lhs),
+            rhs: Box::new(rhs),
+            matching,
+        };
+        Ok(Expr::Binary(ex))
+    }
+
+    pub fn new_aggregate_expr(
+        op: TokenType,
+        grouping: AggModifier,
+        args: FunctionArgs,
+    ) -> Result<Expr, String> {
+        if args.is_empty() {
+            return Err("no arguments for aggregate expression provided".into());
+        }
+
+        let mut desired_args_count = 1;
+        let mut param = None;
+        if token::is_aggregator_with_param(op) {
+            desired_args_count = 2;
+            param = Some(args.first());
+        }
+        if args.len() != desired_args_count {
+            return Err(format!(
+                "wrong number of arguments for aggregate expression provided, expected {}, got {}",
+                desired_args_count,
+                args.len()
+            ));
+        }
+        let ex = AggregateExpr {
+            op,
+            expr: args.last(),
+            param,
+            grouping,
+        };
+        Ok(Expr::Aggregate(ex))
+    }
 }
 
-// VectorMatching describes how elements from two Vectors in a binary
-// operation are supposed to be matched.
-#[derive(Debug, Clone)]
-pub struct VectorMatching {
-    // The cardinality of the two Vectors.
-    pub card: VectorMatchCardinality,
-    // MatchingLabels contains the labels which define equality of a pair of
-    // elements from the Vectors.
-    pub matching_labels: Vec<String>,
-    // On includes the given label names from matching,
-    // rather than excluding them.
-    pub on: bool,
-    // Include contains additional labels that should be included in
-    // the result from the side with the lower cardinality.
-    pub include: Vec<String>,
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_at_modifier() {
+        let cases = vec![
+            // tuple: (seconds, elapsed milliseconds before or after UNIX_EPOCH)
+            (0.0, 0),
+            (1000.3, 1000300),    // after UNIX_EPOCH
+            (1000.9, 1000900),    // after UNIX_EPOCH
+            (1000.9991, 1000999), // after UNIX_EPOCH
+            (1000.9999, 1001000), // after UNIX_EPOCH
+            (-1000.3, 1000300),   // before UNIX_EPOCH
+            (-1000.9, 1000900),   // before UNIX_EPOCH
+        ];
+
+        for (secs, elapsed) in cases {
+            match AtModifier::try_from(secs).unwrap() {
+                AtModifier::At(st) => {
+                    if secs.is_sign_positive() || secs == 0.0 {
+                        assert_eq!(
+                            elapsed,
+                            st.duration_since(SystemTime::UNIX_EPOCH)
+                                .unwrap()
+                                .as_millis()
+                        )
+                    } else if secs.is_sign_negative() {
+                        assert_eq!(
+                            elapsed,
+                            SystemTime::UNIX_EPOCH
+                                .duration_since(st)
+                                .unwrap()
+                                .as_millis()
+                        )
+                    }
+                }
+                _ => panic!(),
+            }
+        }
+    }
+
+    #[test]
+    fn test_invalid_at_modifier() {
+        let cases = vec![
+            f64::MAX,
+            f64::MIN,
+            f64::NAN,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+        ];
+
+        for secs in cases {
+            assert!(AtModifier::try_from(secs).is_err())
+        }
+    }
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -90,7 +90,7 @@ impl TryFrom<Token> for AtModifier {
     type Error = String;
 
     fn try_from(token: Token) -> Result<Self, Self::Error> {
-        AtModifier::try_from(token.id())
+        AtModifier::try_from(token.id)
     }
 }
 
@@ -278,7 +278,7 @@ impl Expr {
                 Expr::NumberLiteral(NumberLiteral { val: -val })
             }
             _ => Expr::Unary(UnaryExpr {
-                op: op.id(),
+                op: op.id,
                 expr: Box::new(expr),
             }),
         };

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -21,12 +21,14 @@ pub mod token;
 pub mod value;
 
 pub use ast::{
-    AggregateExpr, BinaryExpr, Call, EvalStmt, Expr, MatrixSelector, NumberLiteral, ParenExpr,
-    StringLiteral, SubqueryExpr, UnaryExpr, VectorSelector,
+    AggModifier, AggregateExpr, AtModifier, BinModifier, BinaryExpr, Call, EvalStmt, Expr,
+    MatrixSelector, NumberLiteral, Offset, ParenExpr, StringLiteral, SubqueryExpr, UnaryExpr,
+    VectorMatchCardinality, VectorMatchModifier, VectorSelector,
 };
-pub use function::{get_function, Function};
+
+pub use function::{get_function, Function, FunctionArgs};
 pub use lex::{is_label, lexer, LexemeType};
 pub use parse::parse;
 pub use production::{lexeme_to_string, lexeme_to_token, span_to_string};
-pub use token::{Token, TokenType};
+pub use token::{is_aggregator_with_param, Token, TokenType};
 pub use value::{Value, ValueType};

--- a/src/parser/promql.y
+++ b/src/parser/promql.y
@@ -136,14 +136,14 @@ start -> Result<Expr, String>:
 vector_selector -> Result<Expr, String>:
                 metric_identifier label_matchers
                 {
-                        let name = $1.val();
+                        let name = $1.val;
                         let matcher = Matcher::new(MatchOp::Equal, METRIC_NAME.into(), name.clone());
                         let matchers = $2?.append(matcher);
                         Expr::new_vector_selector(Some(name), matchers)
                 }
                 | metric_identifier
                 {
-                        let name = $1.val();
+                        let name = $1.val;
                         let matcher = Matcher::new(MatchOp::Equal, METRIC_NAME.into(), name.clone());
                         let matchers = Matchers::empty().append(matcher);
                         Expr::new_vector_selector(Some(name), matchers)
@@ -168,12 +168,12 @@ label_matcher -> Result<Matcher, String>:
                 {
                         let name = lexeme_to_string($lexer, &$1);
                         let value = lexeme_to_string($lexer, &$3);
-                        Matcher::new_matcher($2.id(), name, value)
+                        Matcher::new_matcher($2.id, name, value)
                 }
                 | IDENTIFIER match_op error
                 {
                         let id = lexeme_to_string($lexer, &$1);
-                        let op = $2.val();
+                        let op = $2.val;
                         let err = $3;
                         Err(format!("matcher err. identifier:{id}, op:{op}, err:{err}"))
                 }
@@ -196,7 +196,7 @@ label_matcher -> Result<Matcher, String>:
 metric -> Result<Labels, String>:
                 metric_identifier label_set
                 {
-                        let label = Label::new(METRIC_NAME.to_string(), $1.val());
+                        let label = Label::new(METRIC_NAME.to_string(), $1.val);
                         Ok($2?.append(label))
                 }
                 | label_set { $1 }

--- a/src/parser/promql.y
+++ b/src/parser/promql.y
@@ -356,9 +356,7 @@ number -> Result<f64, String>:
                 NUMBER
                 {
                         let s = $lexer.span_str($span);
-                        s.parse::<f64>().map_err(|_| format!("ParseFloatError. {s} can't be parsed into f64"))
-                        /* FIXME: rebase after parse_golang_str_radix is merged */
-                        /* parse_golang_str_radix(s) */
+                        parse_golang_str_radix(s)
                 }
                 ;
 
@@ -392,4 +390,4 @@ use crate::parser::{
     Expr, Token, lexeme_to_string, lexeme_to_token, span_to_string,
 };
 use crate::label::{Label, Labels, MatchOp, Matcher, Matchers, METRIC_NAME};
-use crate::util::{parse_duration};
+use crate::util::{parse_duration, parse_golang_str_radix};

--- a/src/parser/token.rs
+++ b/src/parser/token.rs
@@ -152,7 +152,7 @@ pub fn get_keyword_token(s: &str) -> Option<TokenType> {
     KEYWORDS.get(s).copied()
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Token {
     id: TokenType,
     val: String,
@@ -176,6 +176,14 @@ impl Token {
     pub fn val(&self) -> String {
         self.val.clone()
     }
+
+    pub fn is_aggregator_with_param(&self) -> bool {
+        is_aggregator_with_param(self.id())
+    }
+}
+
+pub fn is_aggregator_with_param(id: TokenType) -> bool {
+    id == T_TOPK || id == T_BOTTOMK || id == T_COUNT_VALUES || id == T_QUANTILE
 }
 
 #[cfg(test)]
@@ -192,5 +200,25 @@ mod tests {
     fn test_get_keyword_tokens() {
         assert!(matches!(get_keyword_token("quantile"), Some(T_QUANTILE)));
         assert!(matches!(get_keyword_token("unknown"), None));
+    }
+
+    #[test]
+    fn test_with_param() {
+        assert!(is_aggregator_with_param(T_TOPK));
+        assert!(is_aggregator_with_param(T_BOTTOMK));
+        assert!(is_aggregator_with_param(T_COUNT_VALUES));
+        assert!(is_aggregator_with_param(T_QUANTILE));
+
+        assert!(!is_aggregator_with_param(T_COUNT));
+        assert!(!is_aggregator_with_param(T_SUM));
+
+        assert!(Token::new(T_TOPK, "top".into()).is_aggregator_with_param());
+        assert!(Token::new(T_BOTTOMK, "bottomk".into()).is_aggregator_with_param());
+        assert!(Token::new(T_COUNT_VALUES, "count_values".into()).is_aggregator_with_param());
+        assert!(Token::new(T_QUANTILE, "quantile".into()).is_aggregator_with_param());
+
+        assert!(!Token::new(T_MAX, "max".into()).is_aggregator_with_param());
+        assert!(!Token::new(T_MIN, "min".into()).is_aggregator_with_param());
+        assert!(!Token::new(T_AVG, "avg".into()).is_aggregator_with_param());
     }
 }

--- a/src/parser/token.rs
+++ b/src/parser/token.rs
@@ -154,8 +154,8 @@ pub fn get_keyword_token(s: &str) -> Option<TokenType> {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Token {
-    id: TokenType,
-    val: String,
+    pub id: TokenType,
+    pub val: String,
 }
 
 impl Display for Token {
@@ -169,16 +169,8 @@ impl Token {
         Self { id, val }
     }
 
-    pub fn id(&self) -> TokenType {
-        self.id
-    }
-
-    pub fn val(&self) -> String {
-        self.val.clone()
-    }
-
     pub fn is_aggregator_with_param(&self) -> bool {
-        is_aggregator_with_param(self.id())
+        is_aggregator_with_param(self.id)
     }
 }
 

--- a/src/parser/token.rs
+++ b/src/parser/token.rs
@@ -193,12 +193,21 @@ mod tests {
     #[test]
     fn test_token_display() {
         assert_eq!("@", token_display(T_AT));
+        assert_eq!("sum", token_display(T_SUM));
+        assert_eq!("start", token_display(T_START));
         assert_eq!("unknown token", token_display(255));
     }
 
     #[test]
     fn test_get_keyword_tokens() {
         assert!(matches!(get_keyword_token("quantile"), Some(T_QUANTILE)));
+        assert!(matches!(get_keyword_token("offset"), Some(T_OFFSET)));
+        assert!(matches!(get_keyword_token("on"), Some(T_ON)));
+        assert!(matches!(get_keyword_token("ignoring"), Some(T_IGNORING)));
+        assert!(matches!(get_keyword_token("by"), Some(T_BY)));
+        assert!(matches!(get_keyword_token("without"), Some(T_WITHOUT)));
+
+        assert!(matches!(get_keyword_token("at"), None));
         assert!(matches!(get_keyword_token("unknown"), None));
     }
 


### PR DESCRIPTION
## what's included

- use enum to refactor ast instead of optional fields to match
- implement PartialEq, Eq trait for the ease of comparison
- some `Expr::new_` functions, which will be used in `promql.y` in next PR