### PR TITLE
feat(parser): yacc rules and tests

### DIFF
--- a/src/label/matcher.rs
+++ b/src/label/matcher.rs
@@ -113,6 +113,12 @@ impl Matchers {
         }
     }
 
+    pub fn one(matcher: Matcher) -> Self {
+        let mut matchers = HashSet::new();
+        matchers.insert(matcher);
+        Self { matchers }
+    }
+
     pub fn new(matchers: HashSet<Matcher>) -> Self {
         Self { matchers }
     }

--- a/src/label/matcher.rs
+++ b/src/label/matcher.rs
@@ -114,8 +114,7 @@ impl Matchers {
     }
 
     pub fn one(matcher: Matcher) -> Self {
-        let mut matchers = HashSet::new();
-        matchers.insert(matcher);
+        let matchers = HashSet::from([matcher]);
         Self { matchers }
     }
 

--- a/src/label/mod.rs
+++ b/src/label/mod.rs
@@ -25,7 +25,3 @@ pub const INSTANCE_NAME: &str = "instance";
 
 pub type Label = String;
 pub type Labels = HashSet<Label>;
-
-pub fn empty_labels() -> Labels {
-    HashSet::new()
-}

--- a/src/label/mod.rs
+++ b/src/label/mod.rs
@@ -15,9 +15,17 @@
 mod matcher;
 
 pub use matcher::{MatchOp, Matcher, Matchers};
+use std::collections::HashSet;
 
 // Well-known label names used by Prometheus components.
 pub const METRIC_NAME: &str = "__name__";
 pub const ALERT_NAME: &str = "alertname";
 pub const BUCKET_LABEL: &str = "le";
 pub const INSTANCE_NAME: &str = "instance";
+
+pub type Label = String;
+pub type Labels = HashSet<Label>;
+
+pub fn empty_labels() -> Labels {
+    HashSet::new()
+}

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -13,20 +13,17 @@
 // limitations under the License.
 
 #![allow(dead_code)]
-use crate::label::Matchers;
+use crate::label::{Labels, Matchers};
 use crate::parser::token::{self, T_END, T_START};
 use crate::parser::{Function, FunctionArgs, Token, TokenType};
-use std::collections::HashSet;
 use std::time::{Duration, SystemTime};
-
-type Label = String;
 
 /// Matching Modifier, for VectorMatching of binary expr.
 /// Label lists provided to matching keywords will determine how vectors are combined.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VectorMatchModifier {
-    On(HashSet<Label>),
-    Ignoring(HashSet<Label>),
+    On(Labels),
+    Ignoring(Labels),
 }
 
 /// The label list provided with the group_left or group_right modifier contains
@@ -34,8 +31,8 @@ pub enum VectorMatchModifier {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VectorMatchCardinality {
     OneToOne,
-    ManyToOne(HashSet<Label>),
-    OneToMany(HashSet<Label>),
+    ManyToOne(Labels),
+    OneToMany(Labels),
     // ManyToMany, // useless so far
 }
 
@@ -59,8 +56,8 @@ pub struct BinModifier {
 /// even if their label values are identical between all elements of the vector.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AggModifier {
-    By(HashSet<Label>),
-    Without(HashSet<Label>),
+    By(Labels),
+    Without(Labels),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -54,6 +54,8 @@ pub struct BinModifier {
 /// while all other labels are preserved in the output.
 /// `by` does the opposite and drops labels that are not listed in the by clause,
 /// even if their label values are identical between all elements of the vector.
+///
+/// if empty listed labels, meaning no grouping
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AggModifier {
     By(Labels),
@@ -318,14 +320,6 @@ impl Expr {
         Ok(ex)
     }
 
-    pub fn new_number_literal(val: f64) -> Result<Self, String> {
-        Ok(Expr::NumberLiteral(NumberLiteral { val }))
-    }
-
-    pub fn new_string_literal(val: String) -> Result<Self, String> {
-        Ok(Expr::StringLiteral(StringLiteral { val }))
-    }
-
     /// NOTE: @ and offset is not set here.
     pub fn new_matrix_selector(expr: Expr, range: Duration) -> Result<Self, String> {
         match expr {
@@ -456,6 +450,24 @@ impl Expr {
             grouping,
         };
         Ok(Expr::Aggregate(ex))
+    }
+}
+
+impl From<String> for Expr {
+    fn from(val: String) -> Self {
+        Expr::StringLiteral(StringLiteral { val })
+    }
+}
+
+impl From<&str> for Expr {
+    fn from(s: &str) -> Self {
+        Expr::StringLiteral(StringLiteral { val: s.into() })
+    }
+}
+
+impl From<f64> for Expr {
+    fn from(val: f64) -> Self {
+        Expr::NumberLiteral(NumberLiteral { val })
     }
 }
 

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -360,11 +360,11 @@ impl Lexer {
             }
             // the matched ] has been consumed inside brackets
             ']' => State::Err("unexpected right bracket ']'".into()),
-            ch => State::Err(format!("unexpected character: {ch}")),
+            ch => State::Err(format!("unexpected character: {ch:?}")),
         }
     }
 
-    /// the first number has been seen, so first backup.
+    /// the first number has been consumed, so first backup.
     fn accept_duration(&mut self) -> State {
         self.backup();
         self.scan_number();
@@ -375,7 +375,7 @@ impl Lexer {
         State::Lexeme(T_DURATION)
     }
 
-    /// the first number has been seen, so first backup.
+    /// the first number has been consumed, so first backup.
     fn accept_number_or_duration(&mut self) -> State {
         self.backup();
         if self.scan_number() {
@@ -517,7 +517,7 @@ impl Lexer {
     }
 
     /// scans a string escape sequence. The initial escaping character (\)
-    /// has already been seen.
+    /// has already been consumed.
     // FIXME: more escape logic happens here, mostly to check if number is valid.
     // https://github.com/prometheus/prometheus/blob/0372e259baf014bbade3134fd79bcdfd8cbdef2c/promql/parser/lex.go#L552
     fn accept_escape(&mut self, symbol: char) -> State {
@@ -528,7 +528,7 @@ impl Lexer {
         }
     }
 
-    /// scans a quoted string. The initial quote has already been seen.
+    /// scans a quoted string. The initial quote has already been consumed.
     fn accept_string(&mut self, symbol: char) -> State {
         while let Some(ch) = self.pop() {
             if ch == '\\' {
@@ -593,14 +593,14 @@ impl Lexer {
 
     // this won't affect the cursor.
     fn is_colon_the_first_char_in_brackets(&mut self) -> bool {
-        // note: colon has already been seen, so first backup
+        // note: colon has already been consumed, so first backup
         self.backup();
         let matched = self.last_char_matches(|ch| ch == '[');
         self.pop();
         matched
     }
 
-    // left brackets has already be seen.
+    // left brackets has already be consumed.
     fn inside_brackets(&mut self) -> State {
         match self.pop() {
             Some(ch) if ch.is_ascii_whitespace() => State::Space,
@@ -928,8 +928,8 @@ mod tests {
     #[test]
     fn test_selectors() {
         let cases = vec![
-            ("北京", vec![], Some("unexpected character: 北")),
-            ("北京='a'", vec![], Some("unexpected character: 北")),
+            ("北京", vec![], Some("unexpected character: '北'")),
+            ("北京='a'", vec![], Some("unexpected character: '北'")),
             ("0a='a'", vec![], Some("bad number or duration syntax: 0a")),
             (
                 "{foo='bar'}",

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -352,7 +352,7 @@ impl Lexer {
                 State::Lexeme(T_LEFT_BRACE)
             }
             // the matched } has been consumed inside braces
-            '}' => State::Err("unexpected right bracket '}'".into()),
+            '}' => State::Err("unexpected right brace '}'".into()),
             '[' => {
                 self.reset_colon_scanned();
                 self.dive_into_brackets();
@@ -1056,7 +1056,7 @@ mod tests {
                 vec![(T_LEFT_BRACE, 0, 1)],
                 Some("unexpected end of input inside braces"),
             ),
-            ("}", vec![], Some("unexpected right bracket '}'")),
+            ("}", vec![], Some("unexpected right brace '}'")),
             (
                 "{{",
                 vec![(T_LEFT_BRACE, 0, 1)],

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -477,10 +477,10 @@ mod tests {
             ("}", "unexpected right brace '}'"),
             ("some{", "unexpected end of input inside braces"),
             ("some}", "unexpected right brace '}'"),
-            // (
-            //     "some_metric{a=b}",
-            //     "unexpected identifier \"b\" in label matching, expected string",
-            // ),
+            (
+                "some_metric{a=b}",
+                "unexpected identifier \"b\" in label matching, expected string",
+            ),
             // (
             //     r#"some_metric{a:b="b"}"#,
             //     "unexpected character inside braces: ':'",

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -23,9 +23,855 @@ pub fn parse(input: &str) -> Result<Expr, String> {
                 println!("{err:?}")
             }
             match res {
-                Some(r) => r,
+                Some(r) => check_ast(r),
                 None => Err("empty AST".into()),
             }
         }
+    }
+}
+
+// TODO: check the validation of the expr
+// https://github.com/prometheus/prometheus/blob/0372e259baf014bbade3134fd79bcdfd8cbdef2c/promql/parser/parse.go#L436
+fn check_ast(expr: Result<Expr, String>) -> Result<Expr, String> {
+    expr
+}
+
+/// cases in original prometheus is a huge slices which are constructed more than 3000 lines,
+/// and it is hard to split them based on the original order. So here is the Note:
+///
+/// - all cases SHOULD be covered, and the same literal float and literal
+///   string SHOULD be the same with the original prometheus.
+/// - all cases will be splitted into different blocks based on the type of parsed Expr.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::label::{MatchOp, Matcher, Matchers};
+    use crate::parser::token;
+    use crate::parser::AtModifier as At;
+    use crate::parser::*;
+    use crate::util::duration;
+    use std::collections::HashSet;
+    use std::time::Duration;
+
+    enum Case {
+        Success { input: String, expected: Expr },
+        Fail { input: String, err_msg: String },
+    }
+
+    impl Case {
+        fn new_success_case(input: String, expected: Expr) -> Self {
+            Case::Success { input, expected }
+        }
+        fn new_fail_case(input: String, err_msg: String) -> Self {
+            Case::Fail { input, err_msg }
+        }
+
+        fn new_success_cases(cases: Vec<(&str, Expr)>) -> Vec<Case> {
+            cases
+                .into_iter()
+                .map(|(input, expected)| Case::new_success_case(String::from(input), expected))
+                .collect()
+        }
+
+        fn new_fail_cases(cases: Vec<(&str, &str)>) -> Vec<Case> {
+            cases
+                .into_iter()
+                .map(|(input, err_msg)| {
+                    Case::new_fail_case(String::from(input), String::from(err_msg))
+                })
+                .collect()
+        }
+    }
+
+    fn assert_cases(cases: Vec<Case>) {
+        for case in cases {
+            match case {
+                Case::Success { input, expected } => {
+                    let r = parse(&input);
+                    assert!(r.is_ok(), "\n<parse> {input} failed, err {:?} ", r);
+                    assert_eq!(r.unwrap(), expected, "\n<parse> {} does not match", input);
+                }
+
+                Case::Fail { input, err_msg } => {
+                    let r = parse(&input);
+                    assert!(
+                        r.is_err(),
+                        "\n<parse> '{input}' should failed, actually '{:?}' ",
+                        r
+                    );
+                    let err = r.unwrap_err();
+                    // assert!(
+                    //     &err.contains(&err_msg),
+                    //     "{:?} does not contains '{}'",
+                    //     &err,
+                    //     err_msg
+                    // );
+                    assert_eq!(err, err_msg);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_number_literal_parser() {
+        let cases = vec![
+            ("1", Expr::new_number_literal(1.0).unwrap()),
+            ("+Inf", Expr::new_number_literal(f64::INFINITY).unwrap()),
+            ("-Inf", Expr::new_number_literal(f64::NEG_INFINITY).unwrap()),
+            (".5", Expr::new_number_literal(0.5).unwrap()),
+            ("5.", Expr::new_number_literal(5.0).unwrap()),
+            ("123.4567", Expr::new_number_literal(123.4567).unwrap()),
+            ("5e-3", Expr::new_number_literal(0.005).unwrap()),
+            ("5e3", Expr::new_number_literal(5000.0).unwrap()),
+            ("0xc", Expr::new_number_literal(12.0).unwrap()),
+            ("0755", Expr::new_number_literal(493.0).unwrap()),
+            ("+5.5e-3", Expr::new_number_literal(0.0055).unwrap()),
+            ("-0755", Expr::new_number_literal(-493.0).unwrap()),
+        ];
+        assert_cases(Case::new_success_cases(cases));
+    }
+
+    // TODO: fulfil binary expr parser cases
+    #[test]
+    fn test_vector_binary_expr_parser() {
+        // "1 + 1"
+        // "1 - 1"
+        // "1 * 1"
+        // "1 / 1"
+        // "1 % 1"
+        // "1 == bool 1"
+        // "1 != bool 1"
+        // "1 > bool 1"
+        // "1 >= bool 1"
+        // "1 < bool 1"
+        // "1 <= bool 1"
+        // "-1^2"
+        // "-1*2"
+        // "-1+2"
+        // "-1^-2" // unary on binary expr
+        // "+1 + -2 * 1"
+        // "1 + 2/(3*1)"
+        // "1 < bool 2 - 1 * 2"
+        // "foo * bar"
+        // "foo * sum"
+        // "foo == 1"
+        // "foo == bool 1"
+        // "2.5 / bar"
+        // "foo and bar"
+        // "foo or bar"
+        // "foo unless bar"
+        // "foo + bar or bla and blub"
+        // "foo and bar unless baz or qux"
+        // "bar + on(foo) bla / on(baz, buz) group_right(test) blub"
+        // "foo * on(test,blub) bar"
+        // "foo * on(test,blub) group_left bar"
+        // "foo and on(test,blub) bar"
+        // "foo and on() bar"
+        // "foo and ignoring(test,blub) bar"
+        // "foo and ignoring() bar"
+        // "foo unless on(bar) baz"
+        // "foo / on(test,blub) group_left(bar) bar"
+        // "foo / ignoring(test,blub) group_left(blub) bar"
+        // "foo / ignoring(test,blub) group_left(bar) bar"
+        // "foo - on(test,blub) group_right(bar,foo) bar"
+        // "foo - ignoring(test,blub) group_right(bar,foo) bar"
+
+        let fail_cases = vec![
+            // (
+            //     "foo and 1",
+            //     "set operator \"and\" not allowed in binary scalar expression",
+            // ),
+            // (
+            //     "1 and foo",
+            //     "set operator \"and\" not allowed in binary scalar expression",
+            // ),
+            // (
+            //     "foo or 1",
+            //     "set operator \"or\" not allowed in binary scalar expression",
+            // ),
+            // (
+            //     "1 or foo",
+            //     "set operator \"or\" not allowed in binary scalar expression",
+            // ),
+            // (
+            //     "foo unless 1",
+            //     "set operator \"unless\" not allowed in binary scalar expression",
+            // ),
+            // (
+            //     "1 unless foo",
+            //     "set operator \"unless\" not allowed in binary scalar expression",
+            // ),
+            // (
+            //     "1 or on(bar) foo",
+            //     "vector matching only allowed between instant vectors",
+            // ),
+            // (
+            //     "foo == on(bar) 10",
+            //     "vector matching only allowed between instant vectors",
+            // ),
+            // ("foo + group_left(baz) bar", "unexpected <group_left>"),
+            // (
+            //     "foo and on(bar) group_left(baz) bar",
+            //     "no grouping allowed for \"and\" operation",
+            // ),
+            // (
+            //     "foo and on(bar) group_right(baz) bar",
+            //     "no grouping allowed for \"and\" operation",
+            // ),
+            // (
+            //     "foo or on(bar) group_left(baz) bar",
+            //     "no grouping allowed for \"or\" operation",
+            // ),
+            // (
+            //     "foo or on(bar) group_right(baz) bar",
+            //     "no grouping allowed for \"or\" operation",
+            // ),
+            // (
+            //     "foo unless on(bar) group_left(baz) bar",
+            //     "no grouping allowed for \"unless\" operation",
+            // ),
+            // (
+            //     "foo unless on(bar) group_right(baz) bar",
+            //     "no grouping allowed for \"unless\" operation",
+            // ),
+            // (
+            //     r#"http_requests(group="production"} + on(instance) group_left(job,instance) cpu_count(type="smp"}"#,
+            //     "label \"instance\" must not occur in ON and GROUP clause at once",
+            // ),
+            // (
+            //     "foo + bool bar",
+            //     "bool modifier can only be used on comparison operators",
+            // ),
+            // (
+            //     "foo + bool 10",
+            //     "bool modifier can only be used on comparison operators",
+            // ),
+            // (
+            //     "foo and bool 10",
+            //     "bool modifier can only be used on comparison operators",
+            // ),
+        ];
+        assert_cases(Case::new_fail_cases(fail_cases));
+    }
+
+    // TODO: fulfil unary expr cases
+    #[test]
+    fn test_unary_expr_parser() {
+        // "-some_metric"
+        // "+some_metric"
+        // " +some_metric"
+    }
+
+    #[test]
+    fn test_vector_selector_parser() {
+        let cases = vec![
+            ("foo", {
+                let name = String::from("foo");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                Expr::new_vector_selector(Some(name), Matchers::one(matcher)).unwrap()
+            }),
+            ("min", {
+                let name = String::from("min");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                Expr::new_vector_selector(Some(name), Matchers::one(matcher)).unwrap()
+            }),
+            ("foo offset 5m", {
+                let name = String::from("foo");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                Expr::new_vector_selector(Some(name), Matchers::one(matcher))
+                    .and_then(|e| e.offset_expr(Offset::Pos(Duration::from_secs(60 * 5))))
+                    .unwrap()
+            }),
+            ("foo offset -7m", {
+                let name = String::from("foo");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let offset = Duration::from_secs(60 * 7);
+                Expr::new_vector_selector(Some(name), Matchers::one(matcher))
+                    .and_then(|e| e.offset_expr(Offset::Neg(offset)))
+                    .unwrap()
+            }),
+            ("foo OFFSET 1h30m", {
+                let name = String::from("foo");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let offset = Duration::from_secs(60 * 90);
+
+                Expr::new_vector_selector(Some(name), Matchers::one(matcher))
+                    .and_then(|e| e.offset_expr(Offset::Pos(offset)))
+                    .unwrap()
+            }),
+            ("foo OFFSET 1h30ms", {
+                let name = String::from("foo");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let offset = Duration::from_secs(60 * 60) + Duration::from_millis(30);
+
+                Expr::new_vector_selector(Some(name), Matchers::one(matcher))
+                    .and_then(|e| e.offset_expr(Offset::Pos(offset)))
+                    .unwrap()
+            }),
+            ("foo @ 1603774568", {
+                let name = String::from("foo");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let at = At::try_from(1603774568f64).unwrap();
+
+                Expr::new_vector_selector(Some(name), Matchers::one(matcher))
+                    .and_then(|e| e.step_invariant_expr(at))
+                    .unwrap()
+            }),
+            ("foo @ -100", {
+                let name = String::from("foo");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let at = At::try_from(-100f64).unwrap();
+
+                Expr::new_vector_selector(Some(name), Matchers::one(matcher))
+                    .and_then(|e| e.step_invariant_expr(at))
+                    .unwrap()
+            }),
+            ("foo @ .3", {
+                let name = String::from("foo");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let at = At::try_from(0.3f64).unwrap();
+
+                Expr::new_vector_selector(Some(name), Matchers::one(matcher))
+                    .and_then(|e| e.step_invariant_expr(at))
+                    .unwrap()
+            }),
+            ("foo @ 3.", {
+                let name = String::from("foo");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let at = At::try_from(3f64).unwrap();
+
+                Expr::new_vector_selector(Some(name), Matchers::one(matcher))
+                    .and_then(|e| e.step_invariant_expr(at))
+                    .unwrap()
+            }),
+            ("foo @ 3.33", {
+                let name = String::from("foo");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let at = At::try_from(3.33f64).unwrap();
+
+                Expr::new_vector_selector(Some(name), Matchers::one(matcher))
+                    .and_then(|e| e.step_invariant_expr(at))
+                    .unwrap()
+            }),
+            ("foo @ 3.3333", {
+                let name = String::from("foo");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                // Rounding off
+                let at = At::try_from(3.333f64).unwrap();
+
+                Expr::new_vector_selector(Some(name), Matchers::one(matcher))
+                    .and_then(|e| e.step_invariant_expr(at))
+                    .unwrap()
+            }),
+            ("foo @ 3.3335", {
+                let name = String::from("foo");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                // Rounding off
+                let at = At::try_from(3.334f64).unwrap();
+
+                Expr::new_vector_selector(Some(name), Matchers::one(matcher))
+                    .and_then(|e| e.step_invariant_expr(at))
+                    .unwrap()
+            }),
+            ("foo @ 3e2", {
+                let name = String::from("foo");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let at = At::try_from(300f64).unwrap();
+
+                Expr::new_vector_selector(Some(name), Matchers::one(matcher))
+                    .and_then(|e| e.step_invariant_expr(at))
+                    .unwrap()
+            }),
+            ("foo @ 3e-1", {
+                let name = String::from("foo");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let at = At::try_from(0.3).unwrap();
+
+                Expr::new_vector_selector(Some(name), Matchers::one(matcher))
+                    .and_then(|e| e.step_invariant_expr(at))
+                    .unwrap()
+            }),
+            ("foo @ 0xA", {
+                let name = String::from("foo");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let at = At::try_from(10f64).unwrap();
+
+                Expr::new_vector_selector(Some(name), Matchers::one(matcher))
+                    .and_then(|e| e.step_invariant_expr(at))
+                    .unwrap()
+            }),
+            ("foo @ -3.3e1", {
+                let name = String::from("foo");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let at = At::try_from(-33f64).unwrap();
+
+                Expr::new_vector_selector(Some(name), Matchers::one(matcher))
+                    .and_then(|e| e.step_invariant_expr(at))
+                    .unwrap()
+            }),
+            (r#"foo:bar{a="bc"}"#, {
+                let name = String::from("foo:bar");
+                let matchers = Matchers::new(HashSet::from([
+                    Matcher::new_eq_metric_matcher(name.clone()),
+                    Matcher::new(MatchOp::Equal, String::from("a"), String::from("bc")),
+                ]));
+                Expr::new_vector_selector(Some(name), matchers).unwrap()
+            }),
+            (r#"foo{NaN='bc'}"#, {
+                let name = String::from("foo");
+                let matchers = Matchers::new(HashSet::from([
+                    Matcher::new_eq_metric_matcher(name.clone()),
+                    Matcher::new(MatchOp::Equal, String::from("NaN"), String::from("bc")),
+                ]));
+                Expr::new_vector_selector(Some(name), matchers).unwrap()
+            }),
+            (r#"foo{bar='}'}"#, {
+                let name = String::from("foo");
+                let matchers = Matchers::new(HashSet::from([
+                    Matcher::new_eq_metric_matcher(name.clone()),
+                    Matcher::new(MatchOp::Equal, String::from("bar"), String::from("}")),
+                ]));
+                Expr::new_vector_selector(Some(name), matchers).unwrap()
+            }),
+            (r#"foo{a="b", foo!="bar", test=~"test", bar!~"baz"}"#, {
+                let name = String::from("foo");
+                let matchers = Matchers::new(HashSet::from([
+                    Matcher::new_eq_metric_matcher(name.clone()),
+                    Matcher::new(MatchOp::Equal, String::from("a"), String::from("b")),
+                    Matcher::new(MatchOp::NotEqual, String::from("foo"), String::from("bar")),
+                    Matcher::new_matcher(
+                        token::T_EQL_REGEX,
+                        String::from("test"),
+                        String::from("test"),
+                    )
+                    .unwrap(),
+                    Matcher::new_matcher(
+                        token::T_NEQ_REGEX,
+                        String::from("bar"),
+                        String::from("baz"),
+                    )
+                    .unwrap(),
+                ]));
+                Expr::new_vector_selector(Some(name), matchers).unwrap()
+            }),
+            (r#"foo{a="b", foo!="bar", test=~"test", bar!~"baz",}"#, {
+                let name = String::from("foo");
+                let matchers = Matchers::new(HashSet::from([
+                    Matcher::new_eq_metric_matcher(name.clone()),
+                    Matcher::new(MatchOp::Equal, String::from("a"), String::from("b")),
+                    Matcher::new(MatchOp::NotEqual, String::from("foo"), String::from("bar")),
+                    Matcher::new_matcher(
+                        token::T_EQL_REGEX,
+                        String::from("test"),
+                        String::from("test"),
+                    )
+                    .unwrap(),
+                    Matcher::new_matcher(
+                        token::T_NEQ_REGEX,
+                        String::from("bar"),
+                        String::from("baz"),
+                    )
+                    .unwrap(),
+                ]));
+                Expr::new_vector_selector(Some(name), matchers).unwrap()
+            }),
+        ];
+        assert_cases(Case::new_success_cases(cases));
+
+        // TODO: fulfil these failure cases
+        let fail_cases = vec![
+            ("foo @ +Inf", "timestamp out of bounds for @ modifier: inf"),
+            ("foo @ -Inf", "timestamp out of bounds for @ modifier: -inf"),
+            ("foo @ NaN", "timestamp out of bounds for @ modifier: NaN"),
+            ("{", "unexpected end of input inside braces"),
+            ("}", "unexpected right bracket '}'"),
+            // ("some{", "unexpected end of input inside braces"),
+            // ("some}", "unexpected character: '}'"),
+            // (
+            //     "some_metric{a=b}",
+            //     "unexpected identifier \"b\" in label matching, expected string",
+            // ),
+            // (
+            //     r#"some_metric{a:b="b"}"#,
+            //     "unexpected character inside braces: ':'",
+            // ),
+            // (r#"foo{a*"b"}"#, "unexpected character inside braces: '*'"),
+            // // (
+            // //               r#"foo{a>="b"}"#,
+            // //              // TODO(fabxc): willingly lexing wrong tokens allows for more precise error
+            // //              // messages from the parser - consider if this is an option. "unexpected character inside braces: '>'",
+            // // ),
+            // (
+            //     r#"some_metric{a=\"\xff\"}"#,
+            //     "1:15: parse error: invalid UTF-8 rune",
+            // ),
+            // (
+            //     "foo{gibberish}",
+            //     r#"unexpected "}" in label matching, expected label matching operator"#,
+            // ),
+            // ("foo{1}", "unexpected character inside braces: '1'"),
+            // (
+            //     "{}",
+            //     "vector selector must contain at least one non-empty matcher",
+            // ),
+            // (
+            //     r#"{x=""}"#,
+            //     "vector selector must contain at least one non-empty matcher",
+            // ),
+            // (
+            //     r#"{x=~".*"}"#,
+            //     "vector selector must contain at least one non-empty matcher",
+            // ),
+            // (
+            //     r#"{x!~".+"}"#,
+            //     "vector selector must contain at least one non-empty matcher",
+            // ),
+            // (
+            //     r#"{x!="a"}"#,
+            //     "vector selector must contain at least one non-empty matcher",
+            // ),
+            // (
+            //     r#"foo{__name__="bar"}"#,
+            //     r#"metric name must not be set twice: "foo" or "bar""#,
+            // ),
+            // (
+            //     "foo{__name__= =}",
+            //     r#"1:15: parse error: unexpected "=" in label matching, expected string"#,
+            // ),
+            // (
+            //     "foo{,}",
+            //     r#"unexpected "," in label matching, expected identifier or "}""#,
+            // ),
+            // (
+            //     r#"foo{__name__ == "bar"}"#,
+            //     r#"1:15: parse error: unexpected "=" in label matching, expected string"#,
+            // ),
+            // (
+            //     r#"foo{__name__="bar" lol}"#,
+            //     r#"unexpected identifier "lol" in label matching, expected "," or "}""#,
+            // ),
+        ];
+        assert_cases(Case::new_fail_cases(fail_cases));
+
+        let fail_cases = vec![
+            {
+                let num = f64::MAX - 1f64;
+                let input = format!("foo @ {num}");
+                let err_msg = format!("timestamp out of bounds for @ modifier: {num}");
+                Case::Fail { input, err_msg }
+            },
+            {
+                let num = f64::MIN - 1f64;
+                let input = format!("foo @ {num}");
+                let err_msg = format!("timestamp out of bounds for @ modifier: {num}");
+                Case::Fail { input, err_msg }
+            },
+        ];
+        assert_cases(fail_cases);
+    }
+
+    #[test]
+    fn test_matrix_selector() {
+        let cases = vec![
+            ("test[5s]", {
+                let name = String::from("test");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                Expr::new_vector_selector(Some(name), Matchers::one(matcher))
+                    .and_then(|vs| Expr::new_matrix_selector(vs, Duration::from_secs(5)))
+                    .unwrap()
+            }),
+            ("test[5m]", {
+                let name = String::from("test");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                Expr::new_vector_selector(Some(name), Matchers::one(matcher))
+                    .and_then(|vs| Expr::new_matrix_selector(vs, duration::MINUTE_DURATION * 5))
+                    .unwrap()
+            }),
+            ("test[5m30s]", {
+                let name = String::from("test");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                Expr::new_vector_selector(Some(name), Matchers::one(matcher))
+                    .and_then(|vs| Expr::new_matrix_selector(vs, Duration::from_secs(330)))
+                    .unwrap()
+            }),
+            ("test[5h] OFFSET 5m", {
+                let name = String::from("test");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                Expr::new_vector_selector(Some(name), Matchers::one(matcher))
+                    .and_then(|vs| Expr::new_matrix_selector(vs, duration::HOUR_DURATION * 5))
+                    .and_then(|ms| ms.offset_expr(Offset::Pos(duration::MINUTE_DURATION * 5)))
+                    .unwrap()
+            }),
+            ("test[5d] OFFSET 10s", {
+                let name = String::from("test");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                Expr::new_vector_selector(Some(name), Matchers::one(matcher))
+                    .and_then(|vs| Expr::new_matrix_selector(vs, duration::DAY_DURATION * 5))
+                    .and_then(|ms| ms.offset_expr(Offset::Pos(Duration::from_secs(10))))
+                    .unwrap()
+            }),
+            ("test[5w] offset 2w", {
+                let name = String::from("test");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                Expr::new_vector_selector(Some(name), Matchers::one(matcher))
+                    .and_then(|vs| Expr::new_matrix_selector(vs, duration::WEEK_DURATION * 5))
+                    .and_then(|ms| ms.offset_expr(Offset::Pos(duration::WEEK_DURATION * 2)))
+                    .unwrap()
+            }),
+            (r#"test{a="b"}[5y] OFFSET 3d"#, {
+                let name = String::from("test");
+                let name_matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let label_matcher =
+                    Matcher::new(MatchOp::Equal, String::from("a"), String::from("b"));
+                Expr::new_vector_selector(
+                    Some(name),
+                    Matchers::new(HashSet::from([name_matcher, label_matcher])),
+                )
+                .and_then(|vs| Expr::new_matrix_selector(vs, duration::YEAR_DURATION * 5))
+                .and_then(|ms| ms.offset_expr(Offset::Pos(duration::DAY_DURATION * 3)))
+                .unwrap()
+            }),
+            (r#"test{a="b"}[5y] @ 1603774699"#, {
+                let name = String::from("test");
+                let name_matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let label_matcher =
+                    Matcher::new(MatchOp::Equal, String::from("a"), String::from("b"));
+                Expr::new_vector_selector(
+                    Some(name),
+                    Matchers::new(HashSet::from([name_matcher, label_matcher])),
+                )
+                .and_then(|vs| Expr::new_matrix_selector(vs, duration::YEAR_DURATION * 5))
+                .and_then(|ms| ms.step_invariant_expr(At::try_from(1603774699_f64).unwrap()))
+                .unwrap()
+            }),
+        ];
+
+        assert_cases(Case::new_success_cases(cases));
+
+        // TODO: fulfil these failure cases
+        let fail_cases = vec![
+            ("foo[5mm]", "bad duration syntax: 5mm"),
+            ("foo[5m1]", "bad duration syntax: 5m1]"),
+            ("foo[5m:1m1]", "bad duration syntax: 1m1]"),
+            ("foo[5y1hs]", "not a valid duration string: 5y1hs"),
+            ("foo[5m1h]", "not a valid duration string: 5m1h"),
+            ("foo[5m1m]", "not a valid duration string: 5m1m"),
+            ("foo[0m]", "duration must be greater than 0"),
+            (r#"foo["5m"]"#, r#"unexpected character inside brackets: ""#),
+            (r#"foo[]"#, r#"empty duration string"#),
+            (r#"foo[1]"#, r#"bad duration syntax: 1]"#),
+            // ("some_metric[5m] OFFSET 1", ""),
+            (
+                "some_metric[5m] OFFSET 1mm",
+                "bad number or duration syntax: 1mm",
+            ),
+            // ("some_metric[5m] OFFSET", ""),
+            (
+                "some_metric OFFSET 1m[5m]",
+                "no offset modifiers allowed before range",
+            ),
+            // ("some_metric[5m] @ 1m", ""),
+            // ("some_metric[5m] @", ""),
+            (
+                "some_metric @ 1234 [5m]",
+                "no @ modifiers allowed before range",
+            ),
+            // ("(foo + bar)[5m]", ""),
+        ];
+        assert_cases(Case::new_fail_cases(fail_cases));
+    }
+
+    #[test]
+    fn test_aggregation_expr_parser() {
+        let cases = vec![
+            ("sum by (foo) (some_metric)", {
+                let name = String::from("some_metric");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let matching = AggModifier::By(HashSet::from([String::from("foo")]));
+                let vs = Expr::new_vector_selector(Some(name), Matchers::one(matcher)).unwrap();
+                Expr::new_aggregate_expr(token::T_SUM, matching, FunctionArgs::new_args(vs))
+                    .unwrap()
+            }),
+            ("avg by (foo)(some_metric)", {
+                let name = String::from("some_metric");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let matching = AggModifier::By(HashSet::from([String::from("foo")]));
+                let vs = Expr::new_vector_selector(Some(name), Matchers::one(matcher)).unwrap();
+                Expr::new_aggregate_expr(token::T_AVG, matching, FunctionArgs::new_args(vs))
+                    .unwrap()
+            }),
+            ("max by (foo)(some_metric)", {
+                let name = String::from("some_metric");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let matching = AggModifier::By(HashSet::from([String::from("foo")]));
+                let vs = Expr::new_vector_selector(Some(name), Matchers::one(matcher)).unwrap();
+                Expr::new_aggregate_expr(token::T_MAX, matching, FunctionArgs::new_args(vs))
+                    .unwrap()
+            }),
+            ("sum without (foo) (some_metric)", {
+                let name = String::from("some_metric");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let matching = AggModifier::Without(HashSet::from([String::from("foo")]));
+                let vs = Expr::new_vector_selector(Some(name), Matchers::one(matcher)).unwrap();
+                Expr::new_aggregate_expr(token::T_SUM, matching, FunctionArgs::new_args(vs))
+                    .unwrap()
+            }),
+            ("sum (some_metric) without (foo)", {
+                let name = String::from("some_metric");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let matching = AggModifier::Without(HashSet::from([String::from("foo")]));
+                let vs = Expr::new_vector_selector(Some(name), Matchers::one(matcher)).unwrap();
+                Expr::new_aggregate_expr(token::T_SUM, matching, FunctionArgs::new_args(vs))
+                    .unwrap()
+            }),
+            ("stddev(some_metric)", {
+                let name = String::from("some_metric");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let matching = AggModifier::By(HashSet::new());
+                let vs = Expr::new_vector_selector(Some(name), Matchers::one(matcher)).unwrap();
+                Expr::new_aggregate_expr(token::T_STDDEV, matching, FunctionArgs::new_args(vs))
+                    .unwrap()
+            }),
+            ("stdvar by (foo)(some_metric)", {
+                let name = String::from("some_metric");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let matching = AggModifier::By(HashSet::from([String::from("foo")]));
+                let vs = Expr::new_vector_selector(Some(name), Matchers::one(matcher)).unwrap();
+                Expr::new_aggregate_expr(token::T_STDVAR, matching, FunctionArgs::new_args(vs))
+                    .unwrap()
+            }),
+            ("sum by ()(some_metric)", {
+                let name = String::from("some_metric");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let matching = AggModifier::By(HashSet::new());
+                let vs = Expr::new_vector_selector(Some(name), Matchers::one(matcher)).unwrap();
+                Expr::new_aggregate_expr(token::T_SUM, matching, FunctionArgs::new_args(vs))
+                    .unwrap()
+            }),
+            ("sum by (foo,bar,)(some_metric)", {
+                let name = String::from("some_metric");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let matching =
+                    AggModifier::By(HashSet::from([String::from("foo"), String::from("bar")]));
+                let vs = Expr::new_vector_selector(Some(name), Matchers::one(matcher)).unwrap();
+                Expr::new_aggregate_expr(token::T_SUM, matching, FunctionArgs::new_args(vs))
+                    .unwrap()
+            }),
+            ("sum by (foo,)(some_metric)", {
+                let name = String::from("some_metric");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let matching = AggModifier::By(HashSet::from([String::from("foo")]));
+                let vs = Expr::new_vector_selector(Some(name), Matchers::one(matcher)).unwrap();
+                Expr::new_aggregate_expr(token::T_SUM, matching, FunctionArgs::new_args(vs))
+                    .unwrap()
+            }),
+            ("topk(5, some_metric)", {
+                let name = String::from("some_metric");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let matching = AggModifier::By(HashSet::new());
+                let vs = Expr::new_vector_selector(Some(name), Matchers::one(matcher)).unwrap();
+                let param = Expr::new_number_literal(5.0).unwrap();
+                let args = FunctionArgs::new_args(param).append_args(vs);
+                Expr::new_aggregate_expr(token::T_TOPK, matching, args).unwrap()
+            }),
+            (r#"count_values("value", some_metric)"#, {
+                let name = String::from("some_metric");
+                let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                let matching = AggModifier::By(HashSet::new());
+                let vs = Expr::new_vector_selector(Some(name), Matchers::one(matcher)).unwrap();
+                let param = Expr::new_string_literal("value".into()).unwrap();
+                let args = FunctionArgs::new_args(param).append_args(vs);
+                Expr::new_aggregate_expr(token::T_COUNT_VALUES, matching, args).unwrap()
+            }),
+            (
+                "sum without(and, by, avg, count, alert, annotations)(some_metric)",
+                {
+                    let name = String::from("some_metric");
+                    let matcher = Matcher::new_eq_metric_matcher(name.clone());
+                    let matching = AggModifier::Without(
+                        vec!["and", "by", "avg", "count", "alert", "annotations"]
+                            .into_iter()
+                            .map(String::from)
+                            .collect(),
+                    );
+                    let vs = Expr::new_vector_selector(Some(name), Matchers::one(matcher)).unwrap();
+                    Expr::new_aggregate_expr(token::T_SUM, matching, FunctionArgs::new_args(vs))
+                        .unwrap()
+                },
+            ),
+        ];
+
+        assert_cases(Case::new_success_cases(cases));
+
+        // TODO: fulfil these failure cases
+        let fail_cases = vec![
+            // ("sum without(==)(some_metric)", ""),
+            // ("sum without(,)(some_metric)", ""),
+            // ("sum without(foo,,)(some_metric)", ""),
+            // ("sum some_metric by (test)", ""),
+            // ("sum (some_metric) by test", ""),
+            // ("sum () by (test)", ""),
+            // ("MIN keep_common (some_metric)", ""),
+            // ("MIN (some_metric) keep_common", ""),
+            // ("sum without (test) (some_metric) by (test)", ""),
+            // ("topk(some_metric)", ""),
+            // ("topk(some_metric,)", ""),
+            // ("topk(some_metric, other_metric)", ""),
+            // ("count_values(5, other_metric)", ""),
+            // ("rate(some_metric[5m]) @ 1234", ""),
+        ];
+        assert_cases(Case::new_fail_cases(fail_cases));
+    }
+
+    // TODO: fulfil function call cases
+    #[test]
+    #[ignore]
+    fn test_function_call_parser() {}
+
+    // TODO: fulfil subquery cases
+    #[test]
+    #[ignore]
+    fn test_subquery_parser() {}
+
+    // TODO: fulfil these failure cases
+    #[test]
+    fn test_fail_cases() {
+        let fail_cases = vec![
+            ("", "no expression found in input: ''"),
+            (
+                "# just a comment\n\n",
+                "no expression found in input: '# just a comment\n\n'",
+            ),
+            // ("1+", "unexpected end of input"),
+            (".", "unexpected character: '.'"),
+            ("2.5.", "bad number or duration syntax: 2.5."),
+            ("100..4", "bad number or duration syntax: 100.."),
+            ("0deadbeef", "bad number or duration syntax: 0de"),
+            // ("1 /", "unexpected end of input"),
+            // ("*1", "unexpected <op:*>"),
+            // ("(1))", "unexpected right parenthesis ')'"),
+            // ("((1)", "unclosed left parenthesis"),
+            // ("999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999", "out of range"),
+            // ("(", "unclosed left parenthesis"),
+            // ("1 and 1", "set operator \"and\" not allowed in binary scalar expression"),
+            // ("1 == 1", "1:3: parse error: comparisons between scalars must use BOOL modifier"),
+            // ("1 or 1", "set operator \"or\" not allowed in binary scalar expression"),
+            // ("1 unless 1", "set operator \"unless\" not allowed in binary scalar expression"),
+            // ("1 !~ 1", `unexpected character after '!': '~'`),
+            // ("1 =~ 1", `unexpected character after '=': '~'`),
+            // (`-"string"`, `unary expression only allowed on expressions of type scalar or instant vector, got "string"`),
+            // (`-test[5m]`, `unary expression only allowed on expressions of type scalar or instant vector, got "range vector"`),
+            // ("*test", "unexpected <op:*>"),
+            // ("1 offset 1d", "1:1: parse error: offset modifier must be preceded by an instant vector selector or range vector selector or a subquery"),
+            // (
+            //     "foo offset 1s offset 2s",
+            //     "offset may not be set multiple times",
+            // ),
+            // (
+            //     "a - on(b) ignoring(c) d",
+            //     "1:11: parse error: unexpected <ignoring>",
+            // ),
+        ];
+        assert_cases(Case::new_fail_cases(fail_cases));
     }
 }

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -23,7 +23,7 @@ pub fn parse(input: &str) -> Result<Expr, String> {
                 println!("{err:?}")
             }
             match res {
-                Some(r) => check_ast(r),
+                Some(r) => r,
                 None => Err("empty AST".into()),
             }
         }
@@ -32,8 +32,9 @@ pub fn parse(input: &str) -> Result<Expr, String> {
 
 // TODO: check the validation of the expr
 // https://github.com/prometheus/prometheus/blob/0372e259baf014bbade3134fd79bcdfd8cbdef2c/promql/parser/parse.go#L436
-fn check_ast(expr: Result<Expr, String>) -> Result<Expr, String> {
-    expr
+#[allow(dead_code)]
+fn check_ast(_expr: Expr) -> Result<Expr, String> {
+    todo!();
 }
 
 /// cases in original prometheus is a huge slices which are constructed more than 3000 lines,
@@ -45,8 +46,7 @@ fn check_ast(expr: Result<Expr, String>) -> Result<Expr, String> {
 #[cfg(test)]
 mod tests {
     use crate::label::{MatchOp, Matcher, Matchers};
-    use crate::parser::*;
-    use crate::parser::{token, AtModifier as At};
+    use crate::parser::{token, AggModifier, AtModifier as At, Expr, FunctionArgs, Offset};
     use crate::util::duration;
     use std::collections::HashSet;
     use std::time::Duration;
@@ -86,7 +86,7 @@ mod tests {
     fn assert_cases(cases: Vec<Case>) {
         for Case { input, expected } in cases {
             assert_eq!(
-                parse(&input),
+                crate::parser::parse(&input),
                 expected,
                 "\n<parse> <{input:?}> does not match"
             );

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -44,11 +44,9 @@ fn check_ast(expr: Result<Expr, String>) -> Result<Expr, String> {
 /// - all cases will be splitted into different blocks based on the type of parsed Expr.
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::label::{MatchOp, Matcher, Matchers};
-    use crate::parser::token;
-    use crate::parser::AtModifier as At;
     use crate::parser::*;
+    use crate::parser::{token, AtModifier as At};
     use crate::util::duration;
     use std::collections::HashSet;
     use std::time::Duration;
@@ -99,14 +97,7 @@ mod tests {
                         "\n<parse> '{input}' should failed, actually '{:?}' ",
                         r
                     );
-                    let err = r.unwrap_err();
-                    // assert!(
-                    //     &err.contains(&err_msg),
-                    //     "{:?} does not contains '{}'",
-                    //     &err,
-                    //     err_msg
-                    // );
-                    assert_eq!(err, err_msg);
+                    assert_eq!(r.unwrap_err(), err_msg);
                 }
             }
         }
@@ -131,8 +122,8 @@ mod tests {
         assert_cases(Case::new_success_cases(cases));
     }
 
-    // TODO: fulfil binary expr parser cases
     #[test]
+    #[ignore]
     fn test_vector_binary_expr_parser() {
         // "1 + 1"
         // "1 - 1"
@@ -254,8 +245,8 @@ mod tests {
         assert_cases(Case::new_fail_cases(fail_cases));
     }
 
-    // TODO: fulfil unary expr cases
     #[test]
+    #[ignore]
     fn test_unary_expr_parser() {
         // "-some_metric"
         // "+some_metric"
@@ -478,15 +469,14 @@ mod tests {
         ];
         assert_cases(Case::new_success_cases(cases));
 
-        // TODO: fulfil these failure cases
         let fail_cases = vec![
             ("foo @ +Inf", "timestamp out of bounds for @ modifier: inf"),
             ("foo @ -Inf", "timestamp out of bounds for @ modifier: -inf"),
             ("foo @ NaN", "timestamp out of bounds for @ modifier: NaN"),
             ("{", "unexpected end of input inside braces"),
-            ("}", "unexpected right bracket '}'"),
-            // ("some{", "unexpected end of input inside braces"),
-            // ("some}", "unexpected character: '}'"),
+            ("}", "unexpected right brace '}'"),
+            ("some{", "unexpected end of input inside braces"),
+            ("some}", "unexpected right brace '}'"),
             // (
             //     "some_metric{a=b}",
             //     "unexpected identifier \"b\" in label matching, expected string",

--- a/src/parser/production.rs
+++ b/src/parser/production.rs
@@ -24,8 +24,10 @@ pub fn lexeme_to_string(
     lexer: &dyn NonStreamingLexer<LexemeType, TokenType>,
     lexeme: &Result<LexemeType, LexemeType>,
 ) -> String {
-    let span = lexeme.as_ref().unwrap().span();
-    span_to_string(lexer, span)
+    match *lexeme {
+        Ok(l) => span_to_string(lexer, l.span()),
+        Err(e) => format!("{e:?}"),
+    }
 }
 
 pub fn lexeme_to_token(

--- a/src/parser/production.rs
+++ b/src/parser/production.rs
@@ -23,11 +23,10 @@ pub fn span_to_string(lexer: &dyn NonStreamingLexer<LexemeType, TokenType>, span
 pub fn lexeme_to_string(
     lexer: &dyn NonStreamingLexer<LexemeType, TokenType>,
     lexeme: &Result<LexemeType, LexemeType>,
-) -> String {
-    match *lexeme {
-        Ok(l) => span_to_string(lexer, l.span()),
-        Err(e) => format!("{e:?}"),
-    }
+) -> Result<String, String> {
+    lexeme
+        .map(|l| span_to_string(lexer, l.span()))
+        .map_err(|e| format!("ParseError {e:?}"))
 }
 
 pub fn lexeme_to_token(
@@ -38,6 +37,7 @@ pub fn lexeme_to_token(
     Token::new(lexeme.tok_id(), span_to_string(lexer, lexeme.span()))
 }
 
+// TODO: more test cases
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -59,8 +59,9 @@ mod tests {
         let lexeme = LexemeType::new(token::T_IDENTIFIER, 43, 3);
         let lexer = lex::lexer(input);
         assert!(lexer.is_ok());
+
         let lexeme_str = lexeme_to_string(&lexer.unwrap(), &Ok(lexeme));
-        assert_eq!(lexeme_str, "job");
+        assert_eq!(lexeme_str, Ok(String::from("job")));
     }
 
     #[test]

--- a/src/parser/promql.y
+++ b/src/parser/promql.y
@@ -245,7 +245,11 @@ grouping_labels -> Result<Labels, String>:
                 LEFT_PAREN grouping_label_list RIGHT_PAREN { $2 }
                 | LEFT_PAREN grouping_label_list COMMA RIGHT_PAREN { $2 }
                 | LEFT_PAREN RIGHT_PAREN { Ok(HashSet::new()) }
-                | error { Err(format!("err in grouping opts {}", $1)) }
+                | error
+                {
+                        let err = $1;
+                        Err(format!("err in grouping opts {err}"))
+                }
                 ;
 
 grouping_label_list -> Result<Labels, String>:
@@ -256,16 +260,21 @@ grouping_label_list -> Result<Labels, String>:
                         Ok(v)
                 }
                 | grouping_label { Ok(HashSet::from([$1?.val])) }
-                | grouping_label_list error { Err(format!("err in grouping opts {}", $2)) }
+                | grouping_label_list error
+                {
+                        let err = $2;
+                        Err(format!("err in grouping opts {err}"))
+                }
                 ;
 
 grouping_label -> Result<Token, String>:
                 maybe_label
                 {
-                        if is_label(&$1.val) {
+                        let label = &$1.val;
+                        if is_label(label) {
                             Ok($1)
                         } else {
-                            Err(format!("{} is not valid label in grouping opts", $1.val))
+                            Err(format!("{label} is not valid label in grouping opts"))
                         }
                 }
                 | error { Err($1) }
@@ -279,7 +288,7 @@ function_call -> Result<Expr, String>:
                 {
                         let name = lexeme_to_string($lexer, &$1)?;
                         match get_function(&name) {
-                            None => Err(format!("unknown function with name {}", name)),
+                            None => Err(format!("unknown function with name {name}")),
                             Some(func) => Expr::new_call(func, $2?)
                         }
                 }

--- a/src/parser/promql.y
+++ b/src/parser/promql.y
@@ -282,7 +282,7 @@ grouping_label -> Result<Token, String>:
 function_call -> Result<Expr, String>:
                 IDENTIFIER function_call_body
                 {
-                        let name = lexeme_to_string($lexer, &$1);
+                        let name = lexeme_to_string($lexer, &$1)?;
                         match get_function(&name) {
                             None => Err(format!("unknown function with name {}", name)),
                             Some(func) => Expr::new_call(func, $2?)
@@ -401,20 +401,20 @@ label_match_list -> Result<Matchers, String>:
 label_matcher -> Result<Matcher, String>:
                 IDENTIFIER match_op STRING
                 {
-                        let name = lexeme_to_string($lexer, &$1);
-                        let value = lexeme_to_string($lexer, &$3);
+                        let name = lexeme_to_string($lexer, &$1)?;
+                        let value = lexeme_to_string($lexer, &$3)?;
                         Matcher::new_matcher($2.id, name, value)
                 }
                 | IDENTIFIER match_op error
                 {
-                        let id = lexeme_to_string($lexer, &$1);
+                        let id = lexeme_to_string($lexer, &$1)?;
                         let op = $2.val;
                         let err = $3;
                         Err(format!("matcher err. identifier:{id}, op:{op}, err:{err}"))
                 }
                 | IDENTIFIER error
                 {
-                        let id = lexeme_to_string($lexer, &$1);
+                        let id = lexeme_to_string($lexer, &$1)?;
                         let err = $2;
                         Err(format!("matcher err. identifier:{id}, err:{err}"))
                 }

--- a/src/parser/promql.y
+++ b/src/parser/promql.y
@@ -547,7 +547,7 @@ signed_number -> Result<f64, String>:
                 ;
 
 number -> Result<f64, String>:
-                NUMBER { parse_golang_str_radix($lexer.span_str($span)) }
+                NUMBER { parse_str_radix($lexer.span_str($span)) }
                 ;
 
 duration -> Result<Duration, String>:
@@ -581,4 +581,4 @@ use crate::parser::{
     VectorMatchCardinality, VectorMatchModifier,
     get_function, is_label, lexeme_to_string, lexeme_to_token, span_to_string,
 };
-use crate::util::{parse_duration, parse_golang_str_radix};
+use crate::util::{parse_duration, parse_str_radix};

--- a/src/parser/promql.y
+++ b/src/parser/promql.y
@@ -255,22 +255,17 @@ grouping_label_list -> Result<Labels, String>:
                         v.insert($3?.val);
                         Ok(v)
                 }
-                | grouping_label
-                {
-                        let mut labels = HashSet::new();
-                        labels.insert($1?.val);
-                        Ok(labels)
-                }
+                | grouping_label { Ok(HashSet::from([$1?.val])) }
                 | grouping_label_list error { Err(format!("err in grouping opts {}", $2)) }
                 ;
 
 grouping_label -> Result<Token, String>:
                 maybe_label
                 {
-                        if !is_label(&$1.val) {
-                            Err(format!("{} is not valid label in grouping opts", $1.val))
-                        } else {
+                        if is_label(&$1.val) {
                             Ok($1)
+                        } else {
+                            Err(format!("{} is not valid label in grouping opts", $1.val))
                         }
                 }
                 | error { Err($1) }
@@ -528,7 +523,7 @@ match_op -> Token:
  * Literals.
  */
 number_literal -> Result<Expr, String>:
-                signed_or_unsigned_number { Expr::new_number_literal($1?) }
+                signed_or_unsigned_number { Ok(Expr::from($1?)) }
                 ;
 
 
@@ -543,11 +538,7 @@ signed_number -> Result<f64, String>:
                 ;
 
 number -> Result<f64, String>:
-                NUMBER
-                {
-                        let s = $lexer.span_str($span);
-                        parse_golang_str_radix(s)
-                }
+                NUMBER { parse_golang_str_radix($lexer.span_str($span)) }
                 ;
 
 duration -> Result<Duration, String>:
@@ -555,7 +546,7 @@ duration -> Result<Duration, String>:
                 ;
 
 string_literal -> Result<Expr, String>:
-                STRING { Expr::new_string_literal(span_to_string($lexer, $span)) }
+                STRING { Ok(Expr::from(span_to_string($lexer, $span))) }
                 ;
 
 /*

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -16,4 +16,4 @@ pub mod duration;
 pub mod number;
 
 pub use duration::parse_duration;
-pub use number::parse_golang_str_radix;
+pub use number::parse_str_radix;


### PR DESCRIPTION
## what's included

- all yacc rules, but `BinaryExpr` and `UnaryExpr` are not ready because of grammar conflicts
- parser test cases

## test cases

- all cases in prometheus MUST be covered
- the cases which are commented MUST be implemented in the future

#### included

- StringLiteral
- NumberLiteral
- VectorSelector
- MatrixSelector
- AggregateExpr

#### not included

- Preprocessor, Function Call, ParenExpr, Subquery (These will be covered in next PR)
- BinaryExpr and UnaryExpr (These depends on #31 )