### PR TITLE
feat: disable grmtools error recovery

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -19,6 +19,7 @@ use lrpar::CTParserBuilder;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctp = CTParserBuilder::<DefaultLexeme<u8>, u8>::new()
         .yacckind(YaccKind::Grmtools)
+        .recoverer(lrpar::RecoveryKind::None)
         .grammar_in_src_dir("parser/promql.y")?
         .build()?;
     ct_token_map::<u8>("token_map", ctp.token_map(), None)

--- a/src/label/matcher.rs
+++ b/src/label/matcher.rs
@@ -149,6 +149,7 @@ impl Matchers {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parser::token;
     use std::collections::hash_map::DefaultHasher;
 
     fn hash<H>(op: H) -> u64
@@ -158,6 +159,14 @@ mod tests {
         let mut hasher = DefaultHasher::new();
         op.hash(&mut hasher);
         hasher.finish()
+    }
+
+    #[test]
+    fn test_new_matcher() {
+        assert_eq!(
+            Matcher::new_matcher(token::T_ADD, "".into(), "".into()),
+            Err(format!("invalid match op {}", token::T_ADD))
+        )
     }
 
     #[test]

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -419,6 +419,31 @@ pub struct MatrixSelector {
     pub range: Duration,
 }
 
+/// Call represents Prometheus Function.
+/// Some functions have special cases:
+///
+/// ## exp
+///
+/// exp(v instant-vector) calculates the exponential function for all elements in v.
+/// Special cases are:
+///
+/// ```promql
+/// Exp(+Inf) = +Inf
+/// Exp(NaN) = NaN
+/// ```
+///
+/// ## ln
+///
+/// ln(v instant-vector) calculates the natural logarithm for all elements in v.
+/// Special cases are:
+///
+/// ```promql
+/// ln(+Inf) = +Inf
+/// ln(0) = -Inf
+/// ln(x < 0) = NaN
+/// ln(NaN) = NaN
+/// ```
+/// TODO: support more special cases of function call
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Call {
     pub func: Function,
@@ -658,7 +683,7 @@ impl Expr {
         }
     }
 
-    /// only exists if expr is NumberLiteral
+    /// only Some if expr is NumberLiteral
     pub fn scalar_value(&self) -> Option<f64> {
         match self {
             Expr::NumberLiteral(nl) => Some(nl.val),

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -703,7 +703,7 @@ impl Expr {
         }
     }
 
-    /// only Some if expr is NumberLiteral
+    /// only Some if expr is [Expr::NumberLiteral]
     pub fn scalar_value(&self) -> Option<f64> {
         match self {
             Expr::NumberLiteral(nl) => Some(nl.val),
@@ -1152,82 +1152,69 @@ mod tests {
 
     #[test]
     fn test_at_expr() {
-        let vs =
-            Expr::from(VectorSelector::from("foo")).at_expr(AtModifier::try_from(1.0).unwrap());
-        assert!(vs.is_ok());
-
         assert_eq!(
-            Err("@ <timestamp> may not be set multiple times".into()),
-            vs.unwrap().at_expr(AtModifier::try_from(1.0).unwrap()),
+            "@ <timestamp> may not be set multiple times",
+            Expr::from(VectorSelector::from("foo"))
+                .at_expr(AtModifier::try_from(1.0).unwrap())
+                .and_then(|ex| ex.at_expr(AtModifier::try_from(1.0).unwrap()))
+                .unwrap_err()
         );
 
-        let ms = Expr::new_matrix_selector(
-            Expr::from(VectorSelector::from("foo")),
-            Duration::from_secs(1),
+        assert_eq!(
+            "@ <timestamp> may not be set multiple times",
+            Expr::new_matrix_selector(
+                Expr::from(VectorSelector::from("foo")),
+                Duration::from_secs(1),
+            )
+            .and_then(|ex| ex.at_expr(AtModifier::try_from(1.0).unwrap()))
+            .and_then(|ex| ex.at_expr(AtModifier::try_from(1.0).unwrap()))
+            .unwrap_err()
+        );
+
+        assert_eq!(
+            "@ <timestamp> may not be set multiple times",
+            Expr::new_subquery_expr(
+                Expr::from(VectorSelector::from("foo")),
+                Duration::from_secs(1),
+                None,
+            )
+            .and_then(|ex| ex.at_expr(AtModifier::try_from(1.0).unwrap()))
+            .and_then(|ex| ex.at_expr(AtModifier::try_from(1.0).unwrap()))
+            .unwrap_err()
         )
-        .unwrap()
-        .at_expr(AtModifier::try_from(1.0).unwrap());
-        assert!(ms.is_ok());
-
-        assert_eq!(
-            Err("@ <timestamp> may not be set multiple times".into()),
-            ms.unwrap().at_expr(AtModifier::try_from(1.0).unwrap()),
-        );
-
-        let sq = Expr::new_subquery_expr(
-            Expr::from(VectorSelector::from("foo")),
-            Duration::from_secs(1),
-            None,
-        )
-        .unwrap()
-        .at_expr(AtModifier::try_from(1.0).unwrap());
-        assert!(sq.is_ok());
-
-        assert_eq!(
-            Err("@ <timestamp> may not be set multiple times".into()),
-            sq.unwrap().at_expr(AtModifier::try_from(1.0).unwrap()),
-        );
     }
 
     #[test]
     fn test_offset_expr() {
-        let vs = Expr::from(VectorSelector::from("foo"))
-            .offset_expr(Offset::Pos(Duration::from_secs(1000)));
-        assert!(vs.is_ok());
-
         assert_eq!(
-            Err("offset may not be set multiple times".into()),
-            vs.unwrap()
+            "offset may not be set multiple times",
+            Expr::from(VectorSelector::from("foo"))
                 .offset_expr(Offset::Pos(Duration::from_secs(1000)))
+                .and_then(|ex| ex.offset_expr(Offset::Pos(Duration::from_secs(1000))))
+                .unwrap_err()
         );
 
-        let ms = Expr::new_matrix_selector(
-            Expr::from(VectorSelector::from("foo")),
-            Duration::from_secs(1),
-        )
-        .unwrap()
-        .offset_expr(Offset::Pos(Duration::from_secs(1000)));
-        assert!(ms.is_ok());
-
         assert_eq!(
-            Err("offset may not be set multiple times".into()),
-            ms.unwrap()
-                .offset_expr(Offset::Pos(Duration::from_secs(1000)))
+            "offset may not be set multiple times",
+            Expr::new_matrix_selector(
+                Expr::from(VectorSelector::from("foo")),
+                Duration::from_secs(1),
+            )
+            .and_then(|ex| ex.offset_expr(Offset::Pos(Duration::from_secs(1000))))
+            .and_then(|ex| ex.offset_expr(Offset::Pos(Duration::from_secs(1000))))
+            .unwrap_err()
         );
 
-        let sq = Expr::new_subquery_expr(
-            Expr::from(VectorSelector::from("foo")),
-            Duration::from_secs(1),
-            None,
-        )
-        .unwrap()
-        .offset_expr(Offset::Pos(Duration::from_secs(1000)));
-        assert!(sq.is_ok());
-
         assert_eq!(
-            Err("offset may not be set multiple times".into()),
-            sq.unwrap()
-                .offset_expr(Offset::Pos(Duration::from_secs(1000)))
+            "offset may not be set multiple times",
+            Expr::new_subquery_expr(
+                Expr::from(VectorSelector::from("foo")),
+                Duration::from_secs(1),
+                None,
+            )
+            .and_then(|ex| ex.offset_expr(Offset::Pos(Duration::from_secs(1000))))
+            .and_then(|ex| ex.offset_expr(Offset::Pos(Duration::from_secs(1000))))
+            .unwrap_err()
         );
     }
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -443,7 +443,21 @@ pub struct MatrixSelector {
 /// ln(x < 0) = NaN
 /// ln(NaN) = NaN
 /// ```
+///
 /// TODO: support more special cases of function call
+///
+///  - acos()
+///  - acosh()
+///  - asin()
+///  - asinh()
+///  - atan()
+///  - atanh()
+///  - cos()
+///  - cosh()
+///  - sin()
+///  - sinh()
+///  - tan()
+///  - tanh()
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Call {
     pub func: Function,
@@ -923,22 +937,19 @@ fn check_ast_for_call(ex: Call) -> Result<Expr, String> {
         ));
     }
 
+    // special cases from https://prometheus.io/docs/prometheus/latest/querying/functions
     if name.eq_ignore_ascii_case("exp") && !ex.args.is_empty() {
         if let Some(val) = ex.args.first().scalar_value() {
-            // `exp()` pecial cases are:
-            // exp(+Inf) = +Inf
-            // exp(NaN) = NaN
             if val.is_nan() || val.is_infinite() {
                 return Ok(Expr::Call(ex));
             }
         }
-    } else if name.eq_ignore_ascii_case("ln") && !ex.args.is_empty() {
+    } else if (name.eq_ignore_ascii_case("ln")
+        || name.eq_ignore_ascii_case("log2")
+        || name.eq_ignore_ascii_case("log10"))
+        && !ex.args.is_empty()
+    {
         if let Some(val) = ex.args.first().scalar_value() {
-            // `ln()` special cases are:
-            // ln(+Inf) = +Inf
-            // ln(0) = -Inf
-            // ln(x < 0) = NaN
-            // ln(NaN) = NaN
             if val.is_nan() || val.is_infinite() || val <= 0.0 {
                 return Ok(Expr::Call(ex));
             }

--- a/src/parser/function.rs
+++ b/src/parser/function.rs
@@ -48,14 +48,12 @@ impl FunctionArgs {
         self.args.len()
     }
 
-    /// caller SHOULD take care of the boundary
-    pub fn first(&self) -> Box<Expr> {
-        self.args[0].clone()
+    pub fn first(&self) -> Option<Box<Expr>> {
+        self.args.first().cloned()
     }
 
-    /// caller SHOULD take care of the boundary
-    pub fn last(&self) -> Box<Expr> {
-        self.args[self.len() - 1].clone()
+    pub fn last(&self) -> Option<Box<Expr>> {
+        self.args.last().cloned()
     }
 }
 

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -622,7 +622,7 @@ impl Lexer {
                 State::Lexeme(T_RIGHT_BRACKET)
             }
             Some('[') => State::Err("unexpected left brace '[' inside brackets".into()),
-            Some(ch) => State::Err(format!("unexpected character inside brackets: {ch}")),
+            Some(ch) => State::Err(format!("unexpected character inside brackets: '{ch}'")),
             None => State::Err("unexpected end of input inside brackets".into()),
         }
     }

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -64,6 +64,7 @@ struct Context {
     brace_open: bool,   // Whether a { is opened.
     bracket_open: bool, // Whether a [ is opened.
     got_colon: bool,    // Whether we got a ':' after [ was opened.
+    eof: bool,          // Whether we got end of file
 }
 
 impl Context {
@@ -78,6 +79,7 @@ impl Context {
             brace_open: false,
             bracket_open: false,
             got_colon: false,
+            eof: false,
         }
     }
 
@@ -240,6 +242,14 @@ impl Lexer {
     fn ignore(&mut self) {
         self.ctx.ignore();
     }
+
+    fn is_eof(&self) -> bool {
+        self.ctx.eof
+    }
+
+    fn set_eof(&mut self) {
+        self.ctx.eof = true;
+    }
 }
 
 /// block for state operations.
@@ -278,6 +288,12 @@ impl Lexer {
                 if !self.is_paren_balanced() {
                     return State::Err("unclosed left parenthesis".into());
                 }
+
+                if !self.is_eof() {
+                    self.set_eof();
+                    return State::Lexeme(T_EOF);
+                }
+
                 return State::End;
             }
             Some(ch) => ch,
@@ -704,8 +720,11 @@ mod tests {
                     expected.push(Err(err.unwrap().to_string()));
                 }
 
-                let actual: Vec<Result<LexemeType, String>> =
-                    Lexer::new(input).into_iter().collect();
+                let actual: Vec<Result<LexemeType, String>> = Lexer::new(input)
+                    .into_iter()
+                    // in lex test cases, we don't compare the EOF token
+                    .filter(|r| !matches!(r, Ok(l) if l.tok_id() == T_EOF))
+                    .collect();
                 (input, expected, actual)
             })
             .collect();

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -40,3 +40,5 @@ pub use parse::parse;
 pub use production::{lexeme_to_string, lexeme_to_token, span_to_string};
 pub use token::{Token, TokenId, TokenType};
 pub use value::{Value, ValueType};
+
+pub const INVALID_QUERY_INFO: &str = "invalid promql query";

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -41,4 +41,5 @@ pub use production::{lexeme_to_string, lexeme_to_token, span_to_string};
 pub use token::{Token, TokenId, TokenType};
 pub use value::{Value, ValueType};
 
+// FIXME: show more helpful error message to some invalid promql queries.
 pub const INVALID_QUERY_INFO: &str = "invalid promql query";

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -34,6 +34,8 @@ pub fn parse(input: &str) -> Result<Expr, String> {
 /// - all cases will be splitted into different blocks based on the type of parsed Expr.
 #[cfg(test)]
 mod tests {
+    use regex::Regex;
+
     use crate::label::{MatchOp, Matcher, Matchers};
     use crate::parser::{
         get_function, token, AggModifier, AtModifier as At, BinModifier, Expr, FunctionArgs,
@@ -108,6 +110,7 @@ mod tests {
             ("5e3", Expr::from(5000.0)),
             ("0xc", Expr::from(12.0)),
             ("0755", Expr::from(493.0)),
+            ("08", Expr::from(8.0)),
             ("+5.5e-3", Expr::from(0.0055)),
             ("-0755", Expr::from(-493.0)),
 
@@ -644,6 +647,41 @@ mod tests {
                     Expr::from(VectorSelector::from("sum")),
                 ),
             ),
+            // cases from https://prometheus.io/docs/prometheus/latest/querying/operators
+            (
+                r#"method_code:http_errors:rate5m{code="500"} / ignoring(code) method:http_requests:rate5m"#,
+                {
+                    let name = String::from("method_code:http_errors:rate5m");
+                    let matchers = Matchers::new(HashSet::from([
+                        Matcher::new_eq_metric_matcher(name.clone()),
+                        Matcher::new(MatchOp::Equal, String::from("code"), String::from("500")),
+                    ]));
+                    let lhs = Expr::new_vector_selector(Some(name), matchers).unwrap();
+                    Expr::new_binary_expr(
+                        lhs,
+                        token::T_DIV,
+                        Some(BinModifier::default().with_matching(Some(
+                            VectorMatchModifier::Ignoring(HashSet::from([String::from("code")])),
+                        ))),
+                        Expr::from(VectorSelector::from("method:http_requests:rate5m")),
+                    )
+                },
+            ),
+            (
+                r#"method_code:http_errors:rate5m / ignoring(code) group_left method:http_requests:rate5m"#,
+                Expr::new_binary_expr(
+                    Expr::from(VectorSelector::from("method_code:http_errors:rate5m")),
+                    token::T_DIV,
+                    Some(
+                        BinModifier::default()
+                            .with_matching(Some(VectorMatchModifier::Ignoring(HashSet::from([
+                                String::from("code"),
+                            ]))))
+                            .with_card(VectorMatchCardinality::ManyToOne(HashSet::new())),
+                    ),
+                    Expr::from(VectorSelector::from("method:http_requests:rate5m")),
+                ),
+            ),
         ];
         assert_cases(Case::new_result_cases(cases));
 
@@ -1127,67 +1165,68 @@ mod tests {
             ("sum by (foo) (some_metric)", {
                 let ex = Expr::from(VectorSelector::from("some_metric"));
                 let modifier = AggModifier::By(HashSet::from([String::from("foo")]));
-                Expr::new_aggregate_expr(token::T_SUM, modifier, FunctionArgs::new_args(ex))
+                Expr::new_aggregate_expr(token::T_SUM, Some(modifier), FunctionArgs::new_args(ex))
             }),
             ("avg by (foo)(some_metric)", {
                 let ex = Expr::from(VectorSelector::from("some_metric"));
                 let modifier = AggModifier::By(HashSet::from([String::from("foo")]));
-                Expr::new_aggregate_expr(token::T_AVG, modifier, FunctionArgs::new_args(ex))
+                Expr::new_aggregate_expr(token::T_AVG, Some(modifier), FunctionArgs::new_args(ex))
             }),
             ("max by (foo)(some_metric)", {
                 let modifier = AggModifier::By(HashSet::from([String::from("foo")]));
                 let ex = Expr::from(VectorSelector::from("some_metric"));
-                Expr::new_aggregate_expr(token::T_MAX, modifier, FunctionArgs::new_args(ex))
+                Expr::new_aggregate_expr(token::T_MAX, Some(modifier), FunctionArgs::new_args(ex))
             }),
             ("sum without (foo) (some_metric)", {
                 let modifier = AggModifier::Without(HashSet::from([String::from("foo")]));
                 let ex = Expr::from(VectorSelector::from("some_metric"));
-                Expr::new_aggregate_expr(token::T_SUM, modifier, FunctionArgs::new_args(ex))
+                Expr::new_aggregate_expr(token::T_SUM, Some(modifier), FunctionArgs::new_args(ex))
             }),
             ("sum (some_metric) without (foo)", {
                 let modifier = AggModifier::Without(HashSet::from([String::from("foo")]));
                 let ex = Expr::from(VectorSelector::from("some_metric"));
-                Expr::new_aggregate_expr(token::T_SUM, modifier, FunctionArgs::new_args(ex))
+                Expr::new_aggregate_expr(token::T_SUM, Some(modifier), FunctionArgs::new_args(ex))
             }),
             ("stddev(some_metric)", {
-                let modifier = AggModifier::By(HashSet::new());
                 let ex = Expr::from(VectorSelector::from("some_metric"));
-                Expr::new_aggregate_expr(token::T_STDDEV, modifier, FunctionArgs::new_args(ex))
+                Expr::new_aggregate_expr(token::T_STDDEV, None, FunctionArgs::new_args(ex))
             }),
             ("stdvar by (foo)(some_metric)", {
                 let modifier = AggModifier::By(HashSet::from([String::from("foo")]));
                 let ex = Expr::from(VectorSelector::from("some_metric"));
-                Expr::new_aggregate_expr(token::T_STDVAR, modifier, FunctionArgs::new_args(ex))
+                Expr::new_aggregate_expr(
+                    token::T_STDVAR,
+                    Some(modifier),
+                    FunctionArgs::new_args(ex),
+                )
             }),
             ("sum by ()(some_metric)", {
                 let modifier = AggModifier::By(HashSet::new());
                 let ex = Expr::from(VectorSelector::from("some_metric"));
-                Expr::new_aggregate_expr(token::T_SUM, modifier, FunctionArgs::new_args(ex))
+                Expr::new_aggregate_expr(token::T_SUM, Some(modifier), FunctionArgs::new_args(ex))
             }),
             ("sum by (foo,bar,)(some_metric)", {
                 let modifier =
                     AggModifier::By(HashSet::from([String::from("foo"), String::from("bar")]));
                 let ex = Expr::from(VectorSelector::from("some_metric"));
-                Expr::new_aggregate_expr(token::T_SUM, modifier, FunctionArgs::new_args(ex))
+                Expr::new_aggregate_expr(token::T_SUM, Some(modifier), FunctionArgs::new_args(ex))
             }),
             ("sum by (foo,)(some_metric)", {
                 let modifier = AggModifier::By(HashSet::from([String::from("foo")]));
                 let ex = Expr::from(VectorSelector::from("some_metric"));
-                Expr::new_aggregate_expr(token::T_SUM, modifier, FunctionArgs::new_args(ex))
+                Expr::new_aggregate_expr(token::T_SUM, Some(modifier), FunctionArgs::new_args(ex))
             }),
             ("topk(5, some_metric)", {
-                let modifier = AggModifier::By(HashSet::new());
                 let ex = Expr::from(VectorSelector::from("some_metric"));
                 let param = Expr::from(5.0);
                 let args = FunctionArgs::new_args(param).append_args(ex);
-                Expr::new_aggregate_expr(token::T_TOPK, modifier, args)
+                Expr::new_aggregate_expr(token::T_TOPK, None, args)
             }),
             (r#"count_values("value", some_metric)"#, {
-                let modifier = AggModifier::By(HashSet::new());
                 let ex = Expr::from(VectorSelector::from("some_metric"));
                 let param = Expr::from("value");
                 let args = FunctionArgs::new_args(param).append_args(ex);
-                Expr::new_aggregate_expr(token::T_COUNT_VALUES, modifier, args)
+                Expr::new_aggregate_expr(token::T_COUNT_VALUES, None, args)
             }),
             (
                 "sum without(and, by, avg, count, alert, annotations)(some_metric)",
@@ -1199,13 +1238,16 @@ mod tests {
                             .collect(),
                     );
                     let ex = Expr::from(VectorSelector::from("some_metric"));
-                    Expr::new_aggregate_expr(token::T_SUM, modifier, FunctionArgs::new_args(ex))
+                    Expr::new_aggregate_expr(
+                        token::T_SUM,
+                        Some(modifier),
+                        FunctionArgs::new_args(ex),
+                    )
                 },
             ),
             ("sum(sum)", {
-                let modifier = AggModifier::By(HashSet::new());
                 let ex = Expr::from(VectorSelector::from("sum"));
-                Expr::new_aggregate_expr(token::T_SUM, modifier, FunctionArgs::new_args(ex))
+                Expr::new_aggregate_expr(token::T_SUM, None, FunctionArgs::new_args(ex))
             }),
         ];
         assert_cases(Case::new_result_cases(cases));
@@ -1284,6 +1326,355 @@ mod tests {
                     FunctionArgs::new_args(ex).append_args(Expr::from(5.0)),
                 )
             }),
+            // cases from https://prometheus.io/docs/prometheus/latest/querying/functions
+            (r#"absent(nonexistent{job="myjob"})"#, {
+                let name = String::from("nonexistent");
+                let matchers = Matchers::new(HashSet::from([
+                    Matcher::new_eq_metric_matcher(name.clone()),
+                    Matcher::new(MatchOp::Equal, String::from("job"), String::from("myjob")),
+                ]));
+                let ex = Expr::new_vector_selector(Some(name), matchers).unwrap();
+                Expr::new_call(get_function("absent").unwrap(), FunctionArgs::new_args(ex))
+            }),
+            (r#"absent(nonexistent{job="myjob",instance=~".*"})"#, {
+                let name = String::from("nonexistent");
+                let matchers = Matchers::new(HashSet::from([
+                    Matcher::new_eq_metric_matcher(name.clone()),
+                    Matcher::new(MatchOp::Equal, String::from("job"), String::from("myjob")),
+                    Matcher::new(
+                        MatchOp::Re(Regex::new(".*").unwrap()),
+                        String::from("instance"),
+                        String::from(".*"),
+                    ),
+                ]));
+                Expr::new_vector_selector(Some(name), matchers).and_then(|ex| {
+                    Expr::new_call(get_function("absent").unwrap(), FunctionArgs::new_args(ex))
+                })
+            }),
+            (r#"absent(sum(nonexistent{job="myjob"}))"#, {
+                let name = String::from("nonexistent");
+                let matchers = Matchers::new(HashSet::from([
+                    Matcher::new_eq_metric_matcher(name.clone()),
+                    Matcher::new(MatchOp::Equal, String::from("job"), String::from("myjob")),
+                ]));
+                Expr::new_vector_selector(Some(name), matchers)
+                    .and_then(|ex| {
+                        Expr::new_aggregate_expr(token::T_SUM, None, FunctionArgs::new_args(ex))
+                    })
+                    .and_then(|ex| {
+                        Expr::new_call(get_function("absent").unwrap(), FunctionArgs::new_args(ex))
+                    })
+            }),
+            (r#"absent_over_time(nonexistent{job="myjob"}[1h])"#, {
+                let name = String::from("nonexistent");
+                let matchers = Matchers::new(HashSet::from([
+                    Matcher::new_eq_metric_matcher(name.clone()),
+                    Matcher::new(MatchOp::Equal, String::from("job"), String::from("myjob")),
+                ]));
+                Expr::new_vector_selector(Some(name), matchers)
+                    .and_then(|ex| Expr::new_matrix_selector(ex, duration::HOUR_DURATION))
+                    .and_then(|ex| {
+                        Expr::new_call(
+                            get_function("absent_over_time").unwrap(),
+                            FunctionArgs::new_args(ex),
+                        )
+                    })
+            }),
+            (
+                r#"absent_over_time(nonexistent{job="myjob",instance=~".*"}[1h])"#,
+                {
+                    let name = String::from("nonexistent");
+                    let matchers = Matchers::new(HashSet::from([
+                        Matcher::new_eq_metric_matcher(name.clone()),
+                        Matcher::new(MatchOp::Equal, String::from("job"), String::from("myjob")),
+                        Matcher::new(
+                            MatchOp::Re(Regex::new(".*").unwrap()),
+                            String::from("instance"),
+                            String::from(".*"),
+                        ),
+                    ]));
+                    Expr::new_vector_selector(Some(name), matchers)
+                        .and_then(|ex| Expr::new_matrix_selector(ex, duration::HOUR_DURATION))
+                        .and_then(|ex| {
+                            Expr::new_call(
+                                get_function("absent_over_time").unwrap(),
+                                FunctionArgs::new_args(ex),
+                            )
+                        })
+                },
+            ),
+            (r#"delta(cpu_temp_celsius{host="zeus"}[2h])"#, {
+                let name = String::from("cpu_temp_celsius");
+                let matchers = Matchers::new(HashSet::from([
+                    Matcher::new_eq_metric_matcher(name.clone()),
+                    Matcher::new(MatchOp::Equal, String::from("host"), String::from("zeus")),
+                ]));
+                Expr::new_vector_selector(Some(name), matchers)
+                    .and_then(|ex| Expr::new_matrix_selector(ex, duration::HOUR_DURATION * 2))
+                    .and_then(|ex| {
+                        Expr::new_call(get_function("delta").unwrap(), FunctionArgs::new_args(ex))
+                    })
+            }),
+            (
+                r#"exp(+Inf)"#,
+                Expr::new_call(
+                    get_function("exp").unwrap(),
+                    FunctionArgs::new_args(Expr::from(f64::INFINITY)),
+                ),
+            ),
+            (
+                r#"exp(NaN)"#,
+                Expr::new_call(
+                    get_function("exp").unwrap(),
+                    FunctionArgs::new_args(Expr::from(f64::NAN)),
+                ),
+            ),
+            (
+                r#"histogram_count(rate(http_request_duration_seconds[10m]))"#,
+                {
+                    let name = String::from("http_request_duration_seconds");
+                    let matchers = Matchers::one(Matcher::new_eq_metric_matcher(name.clone()));
+                    Expr::new_vector_selector(Some(name), matchers)
+                        .and_then(|ex| {
+                            Expr::new_matrix_selector(ex, duration::MINUTE_DURATION * 10)
+                        })
+                        .and_then(|ex| {
+                            Expr::new_call(
+                                get_function("rate").unwrap(),
+                                FunctionArgs::new_args(ex),
+                            )
+                        })
+                        .and_then(|ex| {
+                            Expr::new_call(
+                                get_function("histogram_count").unwrap(),
+                                FunctionArgs::new_args(ex),
+                            )
+                        })
+                },
+            ),
+            (
+                r#"histogram_sum(rate(http_request_duration_seconds[10m])) / histogram_count(rate(http_request_duration_seconds[10m]))"#,
+                {
+                    let name = String::from("http_request_duration_seconds");
+                    let matchers = Matchers::one(Matcher::new_eq_metric_matcher(name.clone()));
+                    let rate = Expr::new_vector_selector(Some(name), matchers)
+                        .and_then(|ex| {
+                            Expr::new_matrix_selector(ex, duration::MINUTE_DURATION * 10)
+                        })
+                        .and_then(|ex| {
+                            Expr::new_call(
+                                get_function("rate").unwrap(),
+                                FunctionArgs::new_args(ex),
+                            )
+                        })
+                        .unwrap();
+                    let lhs = Expr::new_call(
+                        get_function("histogram_sum").unwrap(),
+                        FunctionArgs::new_args(rate.clone()),
+                    )
+                    .unwrap();
+                    let rhs = Expr::new_call(
+                        get_function("histogram_count").unwrap(),
+                        FunctionArgs::new_args(rate),
+                    )
+                    .unwrap();
+                    Expr::new_binary_expr(lhs, token::T_DIV, None, rhs)
+                },
+            ),
+            (
+                r#"histogram_fraction(0, 0.2, rate(http_request_duration_seconds[1h]))"#,
+                {
+                    let name = String::from("http_request_duration_seconds");
+                    let matchers = Matchers::one(Matcher::new_eq_metric_matcher(name.clone()));
+                    let rate = Expr::new_vector_selector(Some(name), matchers)
+                        .and_then(|ex| Expr::new_matrix_selector(ex, duration::HOUR_DURATION))
+                        .and_then(|ex| {
+                            Expr::new_call(
+                                get_function("rate").unwrap(),
+                                FunctionArgs::new_args(ex),
+                            )
+                        })
+                        .unwrap();
+                    Expr::new_call(
+                        get_function("histogram_fraction").unwrap(),
+                        FunctionArgs::new_args(Expr::from(0.0_f64))
+                            .append_args(Expr::from(0.2))
+                            .append_args(rate),
+                    )
+                },
+            ),
+            (
+                r#"histogram_quantile(0.9, rate(http_request_duration_seconds_bucket[10m]))"#,
+                {
+                    let name = String::from("http_request_duration_seconds_bucket");
+                    let matchers = Matchers::one(Matcher::new_eq_metric_matcher(name.clone()));
+                    Expr::new_vector_selector(Some(name), matchers)
+                        .and_then(|ex| {
+                            Expr::new_matrix_selector(ex, duration::MINUTE_DURATION * 10)
+                        })
+                        .and_then(|ex| {
+                            Expr::new_call(
+                                get_function("rate").unwrap(),
+                                FunctionArgs::new_args(ex),
+                            )
+                        })
+                        .and_then(|ex| {
+                            Expr::new_call(
+                                get_function("histogram_quantile").unwrap(),
+                                FunctionArgs::new_args(Expr::from(0.9_f64)).append_args(ex),
+                            )
+                        })
+                },
+            ),
+            (
+                r#"histogram_quantile(0.9, sum by (job, le) (rate(http_request_duration_seconds_bucket[10m])))"#,
+                {
+                    let name = String::from("http_request_duration_seconds_bucket");
+                    let matchers = Matchers::one(Matcher::new_eq_metric_matcher(name.clone()));
+                    Expr::new_vector_selector(Some(name), matchers)
+                        .and_then(|ex| {
+                            Expr::new_matrix_selector(ex, duration::MINUTE_DURATION * 10)
+                        })
+                        .and_then(|ex| {
+                            Expr::new_call(
+                                get_function("rate").unwrap(),
+                                FunctionArgs::new_args(ex),
+                            )
+                        })
+                        .and_then(|ex| {
+                            Expr::new_aggregate_expr(
+                                token::T_SUM,
+                                Some(AggModifier::By(HashSet::from([
+                                    String::from("job"),
+                                    String::from("le"),
+                                ]))),
+                                FunctionArgs::new_args(ex),
+                            )
+                        })
+                        .and_then(|ex| {
+                            Expr::new_call(
+                                get_function("histogram_quantile").unwrap(),
+                                FunctionArgs::new_args(Expr::from(0.9_f64)).append_args(ex),
+                            )
+                        })
+                },
+            ),
+            (r#"increase(http_requests_total{job="api-server"}[5m])"#, {
+                let name = String::from("http_requests_total");
+                let matchers = Matchers::new(HashSet::from([
+                    Matcher::new_eq_metric_matcher(name.clone()),
+                    Matcher::new(
+                        MatchOp::Equal,
+                        String::from("job"),
+                        String::from("api-server"),
+                    ),
+                ]));
+                Expr::new_vector_selector(Some(name), matchers)
+                    .and_then(|ex| Expr::new_matrix_selector(ex, duration::MINUTE_DURATION * 5))
+                    .and_then(|ex| {
+                        Expr::new_call(
+                            get_function("increase").unwrap(),
+                            FunctionArgs::new_args(ex),
+                        )
+                    })
+            }),
+            (r#"irate(http_requests_total{job="api-server"}[5m])"#, {
+                let name = String::from("http_requests_total");
+                let matchers = Matchers::new(HashSet::from([
+                    Matcher::new_eq_metric_matcher(name.clone()),
+                    Matcher::new(
+                        MatchOp::Equal,
+                        String::from("job"),
+                        String::from("api-server"),
+                    ),
+                ]));
+                Expr::new_vector_selector(Some(name), matchers)
+                    .and_then(|ex| Expr::new_matrix_selector(ex, duration::MINUTE_DURATION * 5))
+                    .and_then(|ex| {
+                        Expr::new_call(get_function("irate").unwrap(), FunctionArgs::new_args(ex))
+                    })
+            }),
+            (
+                r#"label_join(up{job="api-server",src1="a",src2="b",src3="c"}, "foo", ",", "src1", "src2", "src3")"#,
+                {
+                    let name = String::from("up");
+                    let matchers = Matchers::new(HashSet::from([
+                        Matcher::new_eq_metric_matcher(name.clone()),
+                        Matcher::new(MatchOp::Equal, String::from("src1"), String::from("a")),
+                        Matcher::new(MatchOp::Equal, String::from("src2"), String::from("b")),
+                        Matcher::new(MatchOp::Equal, String::from("src3"), String::from("c")),
+                        Matcher::new(
+                            MatchOp::Equal,
+                            String::from("job"),
+                            String::from("api-server"),
+                        ),
+                    ]));
+                    Expr::new_vector_selector(Some(name), matchers).and_then(|ex| {
+                        Expr::new_call(
+                            get_function("label_join").unwrap(),
+                            FunctionArgs::new_args(ex)
+                                .append_args(Expr::from("foo"))
+                                .append_args(Expr::from(","))
+                                .append_args(Expr::from("src1"))
+                                .append_args(Expr::from("src2"))
+                                .append_args(Expr::from("src3")),
+                        )
+                    })
+                },
+            ),
+            (
+                r#"label_replace(up{job="api-server",service="a:c"}, "foo", "$1", "service", "(.*):.*")"#,
+                {
+                    let name = String::from("up");
+                    let matchers = Matchers::new(HashSet::from([
+                        Matcher::new_eq_metric_matcher(name.clone()),
+                        Matcher::new(MatchOp::Equal, String::from("service"), String::from("a:c")),
+                        Matcher::new(
+                            MatchOp::Equal,
+                            String::from("job"),
+                            String::from("api-server"),
+                        ),
+                    ]));
+                    Expr::new_vector_selector(Some(name), matchers).and_then(|ex| {
+                        Expr::new_call(
+                            get_function("label_replace").unwrap(),
+                            FunctionArgs::new_args(ex)
+                                .append_args(Expr::from("foo"))
+                                .append_args(Expr::from("$1"))
+                                .append_args(Expr::from("service"))
+                                .append_args(Expr::from("(.*):.*")),
+                        )
+                    })
+                },
+            ),
+            (
+                r#"ln(+Inf)"#,
+                Expr::new_call(
+                    get_function("ln").unwrap(),
+                    FunctionArgs::new_args(Expr::from(f64::INFINITY)),
+                ),
+            ),
+            (
+                r#"ln(NaN)"#,
+                Expr::new_call(
+                    get_function("ln").unwrap(),
+                    FunctionArgs::new_args(Expr::from(f64::NAN)),
+                ),
+            ),
+            (
+                r#"ln(0)"#,
+                Expr::new_call(
+                    get_function("ln").unwrap(),
+                    FunctionArgs::new_args(Expr::from(0.0)),
+                ),
+            ),
+            (
+                r#"ln(-1)"#,
+                Expr::new_call(
+                    get_function("ln").unwrap(),
+                    FunctionArgs::new_args(Expr::from(-1.0)),
+                ),
+            ),
         ];
 
         assert_cases(Case::new_result_cases(cases));
@@ -1527,7 +1918,7 @@ mod tests {
                         .collect();
                     Expr::new_aggregate_expr(
                         token::T_SUM,
-                        AggModifier::Without(labels),
+                        Some(AggModifier::Without(labels)),
                         FunctionArgs::new_args(ex),
                     )
                     .and_then(|ex| {

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -21,10 +21,7 @@ pub fn parse(input: &str) -> Result<Expr, String> {
         Ok(lexer) => {
             // NOTE: the errs is ignored so far.
             let (res, _errs) = crate::promql_y::parse(&lexer);
-            match res {
-                Some(r) => r,
-                None => Err("Parse Error".into()),
-            }
+            res.ok_or_else(|| String::from("Parse Error"))?
         }
     }
 }
@@ -965,7 +962,8 @@ mod tests {
             ),
             (
                 r#"foo{__name__ == "bar"}"#,
-                "unexpected '=' in label matching, expected string",
+                // "unexpected '=' in label matching, expected string",
+                "Parse Error",
             ),
             // (
             //     r#"foo{__name__="bar" lol}"#,
@@ -1201,7 +1199,7 @@ mod tests {
             // ("sum without(==)(some_metric)", ""),
             // ("sum without(,)(some_metric)", ""),
             // ("sum without(foo,,)(some_metric)", ""),
-            ("sum some_metric by (test)", "no arguments for aggregate expression 'sum' provided"),
+            ("sum some_metric by (test)", "Parse Error"),
             // ("sum (some_metric) by test", ""),
             (
                 "sum () by (test)",
@@ -1209,8 +1207,8 @@ mod tests {
             ),
             // ("MIN keep_common (some_metric)", ""),
             // ("MIN (some_metric) keep_common", ""),
-            ("sum (some_metric) without (test) by (test)", "ParseError: invalid input at [33:34]"),
-            ("sum without (test) (some_metric) by (test)", "ParseError: invalid input at [33:34]"),
+            ("sum (some_metric) without (test) by (test)", "Parse Error"),
+            ("sum without (test) (some_metric) by (test)", "Parse Error"),
             (
                 "topk(some_metric)",
                 "wrong number of arguments for aggregate expression provided, expected 2, got 1",
@@ -1757,10 +1755,10 @@ mod tests {
     #[test]
     fn test_corner_fail_cases() {
         let fail_cases = vec![
-            ("", "no expression found in input: ''"),
+            ("", "no expression found in input"),
             (
                 "# just a comment\n\n",
-                "no expression found in input: '# just a comment\n\n'",
+                "no expression found in input",
             ),
             // ("1+", ""),
             (".", "unexpected character: '.'"),

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -962,13 +962,13 @@ mod tests {
             ),
             (
                 r#"foo{__name__ == "bar"}"#,
-                // "unexpected '=' in label matching, expected string",
+                "unexpected '=' in label matching, expected string",
+            ),
+            (
+                r#"foo{__name__="bar" lol}"#,
+                // "invalid label matcher, expected label matching operator after 'lol'",
                 "Parse Error",
             ),
-            // (
-            //     r#"foo{__name__="bar" lol}"#,
-            //     "invalid label matcher, expected label matching operator after 'lol'",
-            // ),
         ];
         assert_cases(Case::new_fail_cases(fail_cases));
 
@@ -1079,7 +1079,7 @@ mod tests {
             ),
             (r#"foo[]"#, "missing unit character in duration"),
             (r#"foo[1]"#, r#"bad duration syntax: 1]"#),
-            // ("some_metric[5m] OFFSET 1", ""),
+            // FIXME: ("some_metric[5m] OFFSET 1", ""),
             (
                 "some_metric[5m] OFFSET 1mm",
                 "bad number or duration syntax: 1mm",
@@ -1092,8 +1092,8 @@ mod tests {
                 "some_metric OFFSET 1m[5m]",
                 "no offset modifiers allowed before range",
             ),
-            // ("some_metric[5m] @ 1m", ""),
-            // ("some_metric[5m] @", ""),
+            // FIXME: ("some_metric[5m] @ 1m", ""),
+            // FIXME: ("some_metric[5m] @", ""),
             (
                 "some_metric @ 1234 [5m]",
                 "no @ modifiers allowed before range",
@@ -1196,17 +1196,17 @@ mod tests {
         assert_cases(Case::new_result_cases(cases));
 
         let fail_cases = vec![
-            // ("sum without(==)(some_metric)", ""),
-            // ("sum without(,)(some_metric)", ""),
-            // ("sum without(foo,,)(some_metric)", ""),
+            // FIXME: ("sum without(==)(some_metric)", ""),
+            // FIXME: ("sum without(,)(some_metric)", ""),
+            // FIXME: ("sum without(foo,,)(some_metric)", ""),
             ("sum some_metric by (test)", "Parse Error"),
-            // ("sum (some_metric) by test", ""),
+            // FIXME: ("sum (some_metric) by test", ""),
             (
                 "sum () by (test)",
                 "no arguments for aggregate expression 'sum' provided",
             ),
-            // ("MIN keep_common (some_metric)", ""),
-            // ("MIN (some_metric) keep_common", ""),
+            // FIXME: ("MIN keep_common (some_metric)", ""),
+            // FIXME: ("MIN (some_metric) keep_common", ""),
             ("sum (some_metric) without (test) by (test)", "Parse Error"),
             ("sum without (test) (some_metric) by (test)", "Parse Error"),
             (
@@ -1746,8 +1746,8 @@ mod tests {
         assert_cases(Case::new_result_cases(cases));
 
         let cases = vec![
-            // ("start()", ""),
-            // ("end()", ""),
+            // FIXME: ("start()", ""),
+            // FIXME: ("end()", ""),
         ];
         assert_cases(Case::new_fail_cases(cases));
     }

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -82,16 +82,10 @@ mod tests {
 
     fn assert_cases(cases: Vec<Case>) {
         for Case { input, expected } in cases {
-            let at_most_len = 50;
-            let info = if input.len() >= at_most_len {
-                &input[..at_most_len]
-            } else {
-                &input
-            };
             assert_eq!(
                 crate::parser::parse(&input),
                 expected,
-                "\n<parse> <{info}> does not match"
+                "\n<parse> <{input}> does not match"
             );
         }
     }

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -1417,20 +1417,6 @@ mod tests {
                     })
             }),
             (
-                r#"exp(+Inf)"#,
-                Expr::new_call(
-                    get_function("exp").unwrap(),
-                    FunctionArgs::new_args(Expr::from(f64::INFINITY)),
-                ),
-            ),
-            (
-                r#"exp(NaN)"#,
-                Expr::new_call(
-                    get_function("exp").unwrap(),
-                    FunctionArgs::new_args(Expr::from(f64::NAN)),
-                ),
-            ),
-            (
                 r#"histogram_count(rate(http_request_duration_seconds[10m]))"#,
                 Expr::new_matrix_selector(
                     Expr::from(VectorSelector::from("http_request_duration_seconds")),
@@ -1618,6 +1604,21 @@ mod tests {
                     })
                 },
             ),
+            // special cases
+            (
+                r#"exp(+Inf)"#,
+                Expr::new_call(
+                    get_function("exp").unwrap(),
+                    FunctionArgs::new_args(Expr::from(f64::INFINITY)),
+                ),
+            ),
+            (
+                r#"exp(NaN)"#,
+                Expr::new_call(
+                    get_function("exp").unwrap(),
+                    FunctionArgs::new_args(Expr::from(f64::NAN)),
+                ),
+            ),
             (
                 r#"ln(+Inf)"#,
                 Expr::new_call(
@@ -1643,6 +1644,62 @@ mod tests {
                 r#"ln(-1)"#,
                 Expr::new_call(
                     get_function("ln").unwrap(),
+                    FunctionArgs::new_args(Expr::from(-1.0)),
+                ),
+            ),
+            (
+                r#"log2(+Inf)"#,
+                Expr::new_call(
+                    get_function("log2").unwrap(),
+                    FunctionArgs::new_args(Expr::from(f64::INFINITY)),
+                ),
+            ),
+            (
+                r#"log2(NaN)"#,
+                Expr::new_call(
+                    get_function("log2").unwrap(),
+                    FunctionArgs::new_args(Expr::from(f64::NAN)),
+                ),
+            ),
+            (
+                r#"log2(0)"#,
+                Expr::new_call(
+                    get_function("log2").unwrap(),
+                    FunctionArgs::new_args(Expr::from(0.0)),
+                ),
+            ),
+            (
+                r#"log2(-1)"#,
+                Expr::new_call(
+                    get_function("log2").unwrap(),
+                    FunctionArgs::new_args(Expr::from(-1.0)),
+                ),
+            ),
+            (
+                r#"log10(+Inf)"#,
+                Expr::new_call(
+                    get_function("log10").unwrap(),
+                    FunctionArgs::new_args(Expr::from(f64::INFINITY)),
+                ),
+            ),
+            (
+                r#"log10(NaN)"#,
+                Expr::new_call(
+                    get_function("log10").unwrap(),
+                    FunctionArgs::new_args(Expr::from(f64::NAN)),
+                ),
+            ),
+            (
+                r#"log10(0)"#,
+                Expr::new_call(
+                    get_function("log10").unwrap(),
+                    FunctionArgs::new_args(Expr::from(0.0)),
+                ),
+            ),
+            (
+                r#"log10(-1)"#,
+                Expr::new_call(
+                    get_function("log10").unwrap(),
                     FunctionArgs::new_args(Expr::from(-1.0)),
                 ),
             ),

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -800,7 +800,8 @@ mod tests {
 
         let cases = vec![
             (r#"-"string""#, "unary expression only allowed on expressions of type scalar or instant vector, got: string"),
-            ("-test[5m]", "unary expression only allowed on expressions of type scalar or instant vector, got: range vector")
+            ("-test[5m]", "unary expression only allowed on expressions of type scalar or instant vector, got: range vector"),
+            (r#"-"foo""#, "unary expression only allowed on expressions of type scalar or instant vector, got: string"),
         ];
         assert_cases(Case::new_fail_cases(cases));
     }
@@ -1711,6 +1712,20 @@ mod tests {
             (
                 "rate(some_metric)",
                 "expected type range vector in call to function 'rate', got instant vector",
+            ),
+            (
+                "ln(1)",
+                "expected type instant vector in call to function 'ln', got scalar",
+            ),
+            ("ln()", "expected 1 argument(s) in call to 'ln', got 0"),
+            (
+                "exp(1)",
+                "expected type instant vector in call to function 'exp', got scalar",
+            ),
+            ("exp()", "expected 1 argument(s) in call to 'exp', got 0"),
+            (
+                "label_join()",
+                "expected at least 3 argument(s) in call to 'label_join', got 0",
             ),
             // (r#"label_replace(a, `b`, `c\xff`, `d`, `.*`)"#, ""),
         ];

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -21,7 +21,7 @@ pub fn parse(input: &str) -> Result<Expr, String> {
         Ok(lexer) => {
             // NOTE: the errs is ignored so far.
             let (res, _errs) = crate::promql_y::parse(&lexer);
-            res.ok_or(String::from(INVALID_QUERY_INFO))?
+            res.ok_or_else(|| String::from(INVALID_QUERY_INFO))?
         }
     }
 }

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -23,7 +23,7 @@ pub fn parse(input: &str) -> Result<Expr, String> {
             let (res, _errs) = crate::promql_y::parse(&lexer);
             match res {
                 Some(r) => r,
-                None => Err("empty AST".into()),
+                None => Err("Parse Error".into()),
             }
         }
     }
@@ -1075,15 +1075,21 @@ mod tests {
             ("foo[5m1h]", "not a valid duration string: 5m1h"),
             ("foo[5m1m]", "not a valid duration string: 5m1m"),
             ("foo[0m]", "duration must be greater than 0"),
-            (r#"foo["5m"]"#, r#"unexpected character inside brackets: ""#),
-            (r#"foo[]"#, r#"empty duration string"#),
+            (
+                r#"foo["5m"]"#,
+                r#"unexpected character inside brackets: '"'"#,
+            ),
+            (r#"foo[]"#, "missing unit character in duration"),
             (r#"foo[1]"#, r#"bad duration syntax: 1]"#),
             // ("some_metric[5m] OFFSET 1", ""),
             (
                 "some_metric[5m] OFFSET 1mm",
                 "bad number or duration syntax: 1mm",
             ),
-            ("some_metric[5m] OFFSET", "empty duration string"),
+            (
+                "some_metric[5m] OFFSET",
+                "unexpected end of input in offset, expected duration",
+            ),
             (
                 "some_metric OFFSET 1m[5m]",
                 "no offset modifiers allowed before range",

--- a/src/parser/production.rs
+++ b/src/parser/production.rs
@@ -26,7 +26,7 @@ pub fn lexeme_to_string(
 ) -> Result<String, String> {
     lexeme
         .map(|l| span_to_string(lexer, l.span()))
-        .map_err(map_lexeme_err)
+        .map_err(|_| "ParseError".into())
 }
 
 pub fn lexeme_to_token(
@@ -35,14 +35,7 @@ pub fn lexeme_to_token(
 ) -> Result<Token, String> {
     lexeme
         .map(|l| Token::new(l.tok_id(), span_to_string(lexer, l.span())))
-        .map_err(map_lexeme_err)
-}
-
-fn map_lexeme_err(e: LexemeType) -> String {
-    let span = e.span();
-    let start = span.start();
-    let end = span.end() + 1;
-    format!("ParseError: invalid input at [{start}:{end}]",)
+        .map_err(|_| "ParseError".into())
 }
 
 // TODO: more test cases

--- a/src/parser/promql.y
+++ b/src/parser/promql.y
@@ -155,16 +155,15 @@ expr -> Result<Expr, String>:
 aggregate_expr -> Result<Expr, String>:
                 aggregate_op aggregate_modifier function_call_body
                 {
-                        Expr::new_aggregate_expr($1?.id(), $2?, $3?)
+                        Expr::new_aggregate_expr($1?.id(), Some($2?), $3?)
                 }
         |       aggregate_op function_call_body aggregate_modifier
                 {
-                        Expr::new_aggregate_expr($1?.id(), $3?, $2?)
+                        Expr::new_aggregate_expr($1?.id(), Some($3?), $2?)
                 }
         |       aggregate_op function_call_body
                 {
-                        let modifier = AggModifier::By(HashSet::new());
-                        Expr::new_aggregate_expr($1?.id(), modifier, $2?)
+                        Expr::new_aggregate_expr($1?.id(), None, $2?)
                 }
 ;
 

--- a/src/parser/promql.y
+++ b/src/parser/promql.y
@@ -105,7 +105,7 @@ START_EXPRESSION
 START_METRIC_SELECTOR
 %token STARTSYMBOLS_END
 
-%start expr
+%start start
 
 // Operators are listed with increasing precedence.
 %left LOR
@@ -123,6 +123,12 @@ START_METRIC_SELECTOR
 %right LEFT_BRACKET
 
 %%
+start -> Result<Expr, String>:
+                expr { $1 }
+                | expr EOF { $1 }
+                | EOF { Err("no expression found in input".into()) }
+                ;
+
 expr -> Result<Expr, String>:
 /* check_ast from bottom to up for nested exprs */
                 aggregate_expr { check_ast($1?) }
@@ -297,10 +303,7 @@ offset_expr -> Result<Expr, String>:
                 expr OFFSET duration { $1?.offset_expr(Offset::Pos($3?)) }
                 | expr OFFSET ADD duration { $1?.offset_expr(Offset::Pos($4?)) }
                 | expr OFFSET SUB duration { $1?.offset_expr(Offset::Neg($4?)) }
-                | expr OFFSET
-                {
-                        Err("unexpected end of input in offset, expected duration".into())
-                }
+                | expr OFFSET EOF { Err("unexpected end of input in offset, expected duration".into()) }
                 ;
 
 /*

--- a/src/parser/promql.y
+++ b/src/parser/promql.y
@@ -116,38 +116,38 @@ START_METRIC_SELECTOR
 %right POW
 
 // Offset and At modifiers do not have associativity.
-%nonassoc OFFSET AT
+%nonassoc OFFSET AT GROUP_LEFT GROUP_RIGHT
 
 // This ensures that it is always attempted to parse range or subquery selectors when a left
 // bracket is encountered.
 %right LEFT_BRACKET
-%nonassoc GROUP_LEFT GROUP_RIGHT
-// left_paren has higher precedence, which means when group_left/group_rigth
-// followed by left_paren, the parser it will shift instead of reduce
+
+// left_paren has higher precedence than group_left/group_right, to fix the reduce/shift conflict.
+// if group_left/group_right is followed by left_paren, the parser will shift instead of reduce
 %right LEFT_PAREN
 
 %%
 start -> Result<Expr, String>:
                 expr { $1 }
-                | expr EOF { $1 }
-                | EOF { Err("no expression found in input".into()) }
-                ;
+        |       expr EOF { $1 }
+        |       EOF { Err("no expression found in input".into()) }
+;
 
 expr -> Result<Expr, String>:
 /* check_ast from bottom to up for nested exprs */
                 aggregate_expr { check_ast($1?) }
-                | at_expr { check_ast($1?) }
-                | binary_expr { check_ast($1?) }
-                | function_call { check_ast($1?) }
-                | matrix_selector { check_ast($1?) }
-                | number_literal { check_ast($1?) }
-                | offset_expr { check_ast($1?) }
-                | paren_expr { check_ast($1?) }
-                | string_literal { check_ast($1?) }
-                | subquery_expr { check_ast($1?) }
-                | unary_expr  { check_ast($1?) }
-                | vector_selector  { check_ast($1?) }
-                ;
+        |       at_expr { check_ast($1?) }
+        |       binary_expr { check_ast($1?) }
+        |       function_call { check_ast($1?) }
+        |       matrix_selector { check_ast($1?) }
+        |       number_literal { check_ast($1?) }
+        |       offset_expr { check_ast($1?) }
+        |       paren_expr { check_ast($1?) }
+        |       string_literal { check_ast($1?) }
+        |       subquery_expr { check_ast($1?) }
+        |       unary_expr  { check_ast($1?) }
+        |       vector_selector  { check_ast($1?) }
+;
 
 /*
  * Aggregations.
@@ -157,21 +157,21 @@ aggregate_expr -> Result<Expr, String>:
                 {
                         Expr::new_aggregate_expr($1?.id(), $2?, $3?)
                 }
-                | aggregate_op function_call_body aggregate_modifier
+        |       aggregate_op function_call_body aggregate_modifier
                 {
                         Expr::new_aggregate_expr($1?.id(), $3?, $2?)
                 }
-                | aggregate_op function_call_body
+        |       aggregate_op function_call_body
                 {
                         let modifier = AggModifier::By(HashSet::new());
                         Expr::new_aggregate_expr($1?.id(), modifier, $2?)
                 }
-                ;
+;
 
 aggregate_modifier -> Result<AggModifier, String>:
                 BY grouping_labels { Ok(AggModifier::By($2?)) }
-                | WITHOUT grouping_labels { Ok(AggModifier::Without($2?)) }
-                ;
+        |       WITHOUT grouping_labels { Ok(AggModifier::Without($2?)) }
+;
 
 /*
  * Binary expressions.
@@ -179,77 +179,77 @@ aggregate_modifier -> Result<AggModifier, String>:
 // Operator precedence only works if each of those is listed separately.
 binary_expr -> Result<Expr, String>:
                 expr ADD       bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
-                | expr ATAN2   bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
-                | expr DIV     bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
-                | expr EQLC    bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
-                | expr GTE     bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
-                | expr GTR     bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
-                | expr LAND    bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
-                | expr LOR     bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
-                | expr LSS     bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
-                | expr LTE     bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
-                | expr LUNLESS bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
-                | expr MOD     bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
-                | expr MUL     bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
-                | expr NEQ     bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
-                | expr POW     bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
-                | expr SUB     bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
-                ;
+        |       expr ATAN2   bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
+        |       expr DIV     bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
+        |       expr EQLC    bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
+        |       expr GTE     bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
+        |       expr GTR     bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
+        |       expr LAND    bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
+        |       expr LOR     bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
+        |       expr LSS     bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
+        |       expr LTE     bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
+        |       expr LUNLESS bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
+        |       expr MOD     bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
+        |       expr MUL     bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
+        |       expr NEQ     bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
+        |       expr POW     bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
+        |       expr SUB     bin_modifier expr { Expr::new_binary_expr($1?, lexeme_to_token($lexer, $2)?.id(), $3?, $4?) }
+;
 
 // Using left recursion for the modifier rules, helps to keep the parser stack small and
 // reduces allocations
 bin_modifier -> Result<Option<BinModifier>, String>:
                 group_modifiers { $1 }
-                ;
+;
 
 bool_modifier -> Result<Option<BinModifier>, String>:
                 { Ok(None) }
-                | BOOL
+        |       BOOL
                 {
                         let modifier = BinModifier::default().with_return_bool(true);
                         Ok(Some(modifier))
                 }
-                ;
+;
 
 on_or_ignoring -> Result<Option<BinModifier>, String>:
                 bool_modifier IGNORING grouping_labels
                 {
                         Ok(update_optional_matching($1?, Some(VectorMatchModifier::Ignoring($3?))))
                 }
-                | bool_modifier ON grouping_labels
+        |       bool_modifier ON grouping_labels
                 {
                         Ok(update_optional_matching($1?, Some(VectorMatchModifier::On($3?))))
                 }
-                ;
+;
 
 group_modifiers -> Result<Option<BinModifier>, String>:
                 bool_modifier { $1 }
-                | on_or_ignoring { $1 }
-                | on_or_ignoring GROUP_LEFT grouping_labels
+        |       on_or_ignoring { $1 }
+        |       on_or_ignoring GROUP_LEFT grouping_labels
                 {
                         Ok(update_optional_card($1?, VectorMatchCardinality::ManyToOne($3?)))
                 }
-                | on_or_ignoring GROUP_RIGHT grouping_labels
+        |       on_or_ignoring GROUP_RIGHT grouping_labels
                 {
                         Ok(update_optional_card($1?, VectorMatchCardinality::OneToMany($3?)))
                 }
-                | on_or_ignoring GROUP_LEFT
+        |       on_or_ignoring GROUP_LEFT
                 {
                         Ok(update_optional_card($1?, VectorMatchCardinality::ManyToOne(HashSet::new())))
                 }
-                | on_or_ignoring GROUP_RIGHT
+        |       on_or_ignoring GROUP_RIGHT
                 {
                         Ok(update_optional_card($1?, VectorMatchCardinality::OneToMany(HashSet::new())))
                 }
-                | GROUP_LEFT grouping_labels { Err("unexpected <group_left>".into()) }
-                | GROUP_RIGHT grouping_labels { Err("unexpected <group_right>".into()) }
-                ;
+        |       GROUP_LEFT grouping_labels { Err("unexpected <group_left>".into()) }
+        |       GROUP_RIGHT grouping_labels { Err("unexpected <group_right>".into()) }
+;
 
 grouping_labels -> Result<Labels, String>:
                 LEFT_PAREN grouping_label_list RIGHT_PAREN { $2 }
-                | LEFT_PAREN grouping_label_list COMMA RIGHT_PAREN { $2 }
-                | LEFT_PAREN RIGHT_PAREN { Ok(HashSet::new()) }
-                ;
+        |       LEFT_PAREN grouping_label_list COMMA RIGHT_PAREN { $2 }
+        |       LEFT_PAREN RIGHT_PAREN { Ok(HashSet::new()) }
+;
 
 grouping_label_list -> Result<Labels, String>:
                 grouping_label_list COMMA grouping_label
@@ -258,8 +258,8 @@ grouping_label_list -> Result<Labels, String>:
                         v.insert($3?.val);
                         Ok(v)
                 }
-                | grouping_label { Ok(HashSet::from([$1?.val])) }
-                ;
+        |       grouping_label { Ok(HashSet::from([$1?.val])) }
+;
 
 grouping_label -> Result<Token, String>:
                 maybe_label
@@ -272,7 +272,7 @@ grouping_label -> Result<Token, String>:
                             Err(format!("{label} is not valid label in grouping opts"))
                         }
                 }
-                ;
+;
 
 /*
  * Function calls.
@@ -286,35 +286,40 @@ function_call -> Result<Expr, String>:
                             Some(func) => Expr::new_call(func, $2?)
                         }
                 }
-                ;
+;
 
 function_call_body -> Result<FunctionArgs, String>:
                 LEFT_PAREN function_call_args RIGHT_PAREN { $2 }
-                | LEFT_PAREN RIGHT_PAREN { Ok(FunctionArgs::empty_args()) }
-                ;
+        |       LEFT_PAREN RIGHT_PAREN { Ok(FunctionArgs::empty_args()) }
+;
 
 function_call_args -> Result<FunctionArgs, String>:
                 function_call_args COMMA expr { Ok($1?.append_args($3?)) }
-                | expr { Ok(FunctionArgs::new_args($1?)) }
-                | function_call_args COMMA { Err("trailing commas not allowed in function call args".into()) }
-                ;
+        |       expr { Ok(FunctionArgs::new_args($1?)) }
+        |       function_call_args COMMA { Err("trailing commas not allowed in function call args".into()) }
+;
 
 /*
  * Expressions inside parentheses.
  */
 paren_expr -> Result<Expr, String>:
                 LEFT_PAREN expr RIGHT_PAREN { Expr::new_paren_expr($2?) }
-                ;
+;
 
 /*
  * Offset modifiers.
  */
 offset_expr -> Result<Expr, String>:
                 expr OFFSET duration { $1?.offset_expr(Offset::Pos($3?)) }
-                | expr OFFSET ADD duration { $1?.offset_expr(Offset::Pos($4?)) }
-                | expr OFFSET SUB duration { $1?.offset_expr(Offset::Neg($4?)) }
-                | expr OFFSET EOF { Err("unexpected end of input in offset, expected duration".into()) }
-                ;
+        |       expr OFFSET ADD duration { $1?.offset_expr(Offset::Pos($4?)) }
+        |       expr OFFSET SUB duration { $1?.offset_expr(Offset::Neg($4?)) }
+        |       expr OFFSET NUMBER
+                {
+                        let num = parse_str_radix(&lexeme_to_string($lexer, &$3)?)?;
+                        Err(format!("unexpected number '{num}' in offset, expected duration"))
+                }
+        |       expr OFFSET EOF { Err("unexpected end of input in offset, expected duration".into()) }
+;
 
 /*
  * @ modifiers.
@@ -323,23 +328,32 @@ offset_expr -> Result<Expr, String>:
  */
 at_expr -> Result<Expr, String>:
                 expr AT number_literal { $1?.at_expr(AtModifier::try_from($3?)?) }
-                | expr AT ADD number_literal { $1?.at_expr(AtModifier::try_from($4?)?) }
-                | expr AT SUB number_literal
+        |       expr AT ADD number_literal { $1?.at_expr(AtModifier::try_from($4?)?) }
+        |       expr AT SUB number_literal
                 {
                         let nl = $4.map(|nl| -nl);
                         $1?.at_expr(AtModifier::try_from(nl?)?)
                 }
-                | expr AT at_modifier_preprocessors LEFT_PAREN RIGHT_PAREN
+        |       expr AT at_modifier_preprocessors LEFT_PAREN RIGHT_PAREN
                 {
                         let at = AtModifier::try_from($3?)?;
                         $1?.at_expr(at)
                 }
-                ;
+        |       expr AT DURATION
+                {
+                        let du = lexeme_to_string($lexer, &$3)?;
+                        Err(format!("unexpected duration '{du}' in @, expected timestamp"))
+                }
+        |       expr AT EOF
+                {
+                        Err("unexpected end of input in @, expected timestamp".into())
+                }
+;
 
 at_modifier_preprocessors -> Result<Token, String>:
                 START { lexeme_to_token($lexer, $1) }
-                | END { lexeme_to_token($lexer, $1) }
-                ;
+        |       END { lexeme_to_token($lexer, $1) }
+;
 
 /*
  * Subquery and range selectors.
@@ -349,26 +363,26 @@ matrix_selector -> Result<Expr, String>:
                 {
                         Expr::new_matrix_selector($1?, $3?)
                 }
-                | expr LEFT_BRACKET RIGHT_BRACKET
+        |       expr LEFT_BRACKET RIGHT_BRACKET
                 {
                         Err("missing unit character in duration".into())
                 }
-                ;
+;
 
 subquery_expr -> Result<Expr, String>:
                 expr LEFT_BRACKET duration COLON maybe_duration RIGHT_BRACKET
                 {
                         Expr::new_subquery_expr($1?, $3?, $5?)
                 }
-                ;
+;
 
 /*
  * Unary expressions.
  */
 unary_expr -> Result<Expr, String>:
                 ADD expr %prec MUL { $2 }
-                | SUB expr %prec MUL { Expr::new_unary_expr($2?) }
-                ;
+        |       SUB expr %prec MUL { Expr::new_unary_expr($2?) }
+;
 
 /*
  * Vector selectors.
@@ -381,28 +395,28 @@ vector_selector -> Result<Expr, String>:
                         let matchers = $2?.append(matcher);
                         Expr::new_vector_selector(Some(name), matchers)
                 }
-                | metric_identifier
+        |       metric_identifier
                 {
                         let name = $1?.val;
                         let matcher = Matcher::new_eq_metric_matcher(name.clone());
                         let matchers = Matchers::empty().append(matcher);
                         Expr::new_vector_selector(Some(name), matchers)
                 }
-                | label_matchers { Expr::new_vector_selector(None, $1?) }
-                ;
+        |       label_matchers { Expr::new_vector_selector(None, $1?) }
+;
 
 label_matchers -> Result<Matchers, String>:
                 LEFT_BRACE label_match_list RIGHT_BRACE { $2 }
-                | LEFT_BRACE label_match_list COMMA RIGHT_BRACE { $2 }
-                | LEFT_BRACE RIGHT_BRACE { Ok(Matchers::empty()) }
-                | LEFT_BRACE COMMA RIGHT_BRACE
+        |       LEFT_BRACE label_match_list COMMA RIGHT_BRACE { $2 }
+        |       LEFT_BRACE RIGHT_BRACE { Ok(Matchers::empty()) }
+        |       LEFT_BRACE COMMA RIGHT_BRACE
                 { Err("unexpected ',' in label matching, expected identifier or right_brace".into()) }
-                ;
+;
 
 label_match_list -> Result<Matchers, String>:
                 label_match_list COMMA label_matcher { Ok($1?.append($3?)) }
-                | label_matcher { Ok(Matchers::empty().append($1?)) }
-                ;
+        |       label_matcher { Ok(Matchers::empty().append($1?)) }
+;
 
 label_matcher -> Result<Matcher, String>:
                 IDENTIFIER match_op STRING
@@ -411,63 +425,63 @@ label_matcher -> Result<Matcher, String>:
                         let value = lexeme_to_string($lexer, &$3)?;
                         Matcher::new_matcher($2?.id(), name, value)
                 }
-                | IDENTIFIER match_op match_op
+        |       IDENTIFIER match_op match_op
                 {
                         let op = $3?.val;
                         Err(format!("unexpected '{op}' in label matching, expected string"))
 
                 }
-                | IDENTIFIER match_op match_op STRING
+        |       IDENTIFIER match_op match_op STRING
                 {
                         let op = $3?.val;
                         Err(format!("unexpected '{op}' in label matching, expected string"))
 
                 }
-                | IDENTIFIER match_op match_op IDENTIFIER
+        |       IDENTIFIER match_op match_op IDENTIFIER
                 {
                         let op = $3?.val;
                         Err(format!("unexpected '{op}' in label matching, expected string"))
 
                 }
-                | IDENTIFIER match_op IDENTIFIER
+        |       IDENTIFIER match_op IDENTIFIER
                 {
                         let id = lexeme_to_string($lexer, &$3)?;
                         Err(format!("unexpected identifier '{id}' in label matching, expected string"))
                 }
-                | IDENTIFIER
+        |       IDENTIFIER
                 {
                         let id = lexeme_to_string($lexer, &$1)?;
                         Err(format!("invalid label matcher, expected label matching operator after '{id}'"))
                 }
-                ;
+;
 
 /*
  * Metric descriptions.
  */
 metric_identifier -> Result<Token, String>:
                 AVG { lexeme_to_token($lexer, $1) }
-                | BOTTOMK { lexeme_to_token($lexer, $1) }
-                | BY { lexeme_to_token($lexer, $1) }
-                | COUNT { lexeme_to_token($lexer, $1) }
-                | COUNT_VALUES { lexeme_to_token($lexer, $1) }
-                | GROUP { lexeme_to_token($lexer, $1) }
-                | IDENTIFIER { lexeme_to_token($lexer, $1) }
-                | LAND { lexeme_to_token($lexer, $1) }
-                | LOR { lexeme_to_token($lexer, $1) }
-                | LUNLESS { lexeme_to_token($lexer, $1) }
-                | MAX { lexeme_to_token($lexer, $1) }
-                | METRIC_IDENTIFIER { lexeme_to_token($lexer, $1) }
-                | MIN { lexeme_to_token($lexer, $1) }
-                | OFFSET { lexeme_to_token($lexer, $1) }
-                | QUANTILE { lexeme_to_token($lexer, $1) }
-                | STDDEV { lexeme_to_token($lexer, $1) }
-                | STDVAR { lexeme_to_token($lexer, $1) }
-                | SUM { lexeme_to_token($lexer, $1) }
-                | TOPK { lexeme_to_token($lexer, $1) }
-                | WITHOUT { lexeme_to_token($lexer, $1) }
-                | START { lexeme_to_token($lexer, $1) }
-                | END { lexeme_to_token($lexer, $1) }
-                ;
+        |       BOTTOMK { lexeme_to_token($lexer, $1) }
+        |       BY { lexeme_to_token($lexer, $1) }
+        |       COUNT { lexeme_to_token($lexer, $1) }
+        |       COUNT_VALUES { lexeme_to_token($lexer, $1) }
+        |       GROUP { lexeme_to_token($lexer, $1) }
+        |       IDENTIFIER { lexeme_to_token($lexer, $1) }
+        |       LAND { lexeme_to_token($lexer, $1) }
+        |       LOR { lexeme_to_token($lexer, $1) }
+        |       LUNLESS { lexeme_to_token($lexer, $1) }
+        |       MAX { lexeme_to_token($lexer, $1) }
+        |       METRIC_IDENTIFIER { lexeme_to_token($lexer, $1) }
+        |       MIN { lexeme_to_token($lexer, $1) }
+        |       OFFSET { lexeme_to_token($lexer, $1) }
+        |       QUANTILE { lexeme_to_token($lexer, $1) }
+        |       STDDEV { lexeme_to_token($lexer, $1) }
+        |       STDVAR { lexeme_to_token($lexer, $1) }
+        |       SUM { lexeme_to_token($lexer, $1) }
+        |       TOPK { lexeme_to_token($lexer, $1) }
+        |       WITHOUT { lexeme_to_token($lexer, $1) }
+        |       START { lexeme_to_token($lexer, $1) }
+        |       END { lexeme_to_token($lexer, $1) }
+;
 
 /*
  * Series descriptions (only used by unit tests).
@@ -479,57 +493,57 @@ metric_identifier -> Result<Token, String>:
  */
 aggregate_op -> Result<Token, String>:
                 AVG { lexeme_to_token($lexer, $1) }
-                | BOTTOMK { lexeme_to_token($lexer, $1) }
-                | COUNT { lexeme_to_token($lexer, $1) }
-                | COUNT_VALUES { lexeme_to_token($lexer, $1) }
-                | GROUP { lexeme_to_token($lexer, $1) }
-                | MAX { lexeme_to_token($lexer, $1) }
-                | MIN { lexeme_to_token($lexer, $1) }
-                | QUANTILE { lexeme_to_token($lexer, $1) }
-                | STDDEV { lexeme_to_token($lexer, $1) }
-                | STDVAR { lexeme_to_token($lexer, $1) }
-                | SUM { lexeme_to_token($lexer, $1) }
-                | TOPK { lexeme_to_token($lexer, $1) }
-                ;
+        |       BOTTOMK { lexeme_to_token($lexer, $1) }
+        |       COUNT { lexeme_to_token($lexer, $1) }
+        |       COUNT_VALUES { lexeme_to_token($lexer, $1) }
+        |       GROUP { lexeme_to_token($lexer, $1) }
+        |       MAX { lexeme_to_token($lexer, $1) }
+        |       MIN { lexeme_to_token($lexer, $1) }
+        |       QUANTILE { lexeme_to_token($lexer, $1) }
+        |       STDDEV { lexeme_to_token($lexer, $1) }
+        |       STDVAR { lexeme_to_token($lexer, $1) }
+        |       SUM { lexeme_to_token($lexer, $1) }
+        |       TOPK { lexeme_to_token($lexer, $1) }
+;
 
 // inside of grouping options label names can be recognized as keywords by the lexer.
 // This is a list of keywords that could also be a label name.
 maybe_label -> Result<Token, String>:
                 AVG { lexeme_to_token($lexer, $1) }
-                | BOOL { lexeme_to_token($lexer, $1) }
-                | BOTTOMK { lexeme_to_token($lexer, $1) }
-                | BY { lexeme_to_token($lexer, $1) }
-                | COUNT { lexeme_to_token($lexer, $1) }
-                | COUNT_VALUES { lexeme_to_token($lexer, $1) }
-                | GROUP { lexeme_to_token($lexer, $1) }
-                | GROUP_LEFT { lexeme_to_token($lexer, $1) }
-                | GROUP_RIGHT { lexeme_to_token($lexer, $1) }
-                | IDENTIFIER { lexeme_to_token($lexer, $1) }
-                | IGNORING { lexeme_to_token($lexer, $1) }
-                | LAND { lexeme_to_token($lexer, $1) }
-                | LOR { lexeme_to_token($lexer, $1) }
-                | LUNLESS { lexeme_to_token($lexer, $1) }
-                | MAX { lexeme_to_token($lexer, $1) }
-                | METRIC_IDENTIFIER { lexeme_to_token($lexer, $1) }
-                | MIN { lexeme_to_token($lexer, $1) }
-                | OFFSET { lexeme_to_token($lexer, $1) }
-                | ON { lexeme_to_token($lexer, $1) }
-                | QUANTILE { lexeme_to_token($lexer, $1) }
-                | STDDEV { lexeme_to_token($lexer, $1) }
-                | STDVAR { lexeme_to_token($lexer, $1) }
-                | SUM { lexeme_to_token($lexer, $1) }
-                | TOPK { lexeme_to_token($lexer, $1) }
-                | START { lexeme_to_token($lexer, $1) }
-                | END { lexeme_to_token($lexer, $1) }
-                | ATAN2 { lexeme_to_token($lexer, $1) }
-                ;
+        |       BOOL { lexeme_to_token($lexer, $1) }
+        |       BOTTOMK { lexeme_to_token($lexer, $1) }
+        |       BY { lexeme_to_token($lexer, $1) }
+        |       COUNT { lexeme_to_token($lexer, $1) }
+        |       COUNT_VALUES { lexeme_to_token($lexer, $1) }
+        |       GROUP { lexeme_to_token($lexer, $1) }
+        |       GROUP_LEFT { lexeme_to_token($lexer, $1) }
+        |       GROUP_RIGHT { lexeme_to_token($lexer, $1) }
+        |       IDENTIFIER { lexeme_to_token($lexer, $1) }
+        |       IGNORING { lexeme_to_token($lexer, $1) }
+        |       LAND { lexeme_to_token($lexer, $1) }
+        |       LOR { lexeme_to_token($lexer, $1) }
+        |       LUNLESS { lexeme_to_token($lexer, $1) }
+        |       MAX { lexeme_to_token($lexer, $1) }
+        |       METRIC_IDENTIFIER { lexeme_to_token($lexer, $1) }
+        |       MIN { lexeme_to_token($lexer, $1) }
+        |       OFFSET { lexeme_to_token($lexer, $1) }
+        |       ON { lexeme_to_token($lexer, $1) }
+        |       QUANTILE { lexeme_to_token($lexer, $1) }
+        |       STDDEV { lexeme_to_token($lexer, $1) }
+        |       STDVAR { lexeme_to_token($lexer, $1) }
+        |       SUM { lexeme_to_token($lexer, $1) }
+        |       TOPK { lexeme_to_token($lexer, $1) }
+        |       START { lexeme_to_token($lexer, $1) }
+        |       END { lexeme_to_token($lexer, $1) }
+        |       ATAN2 { lexeme_to_token($lexer, $1) }
+;
 
 match_op -> Result<Token, String>:
                 EQL { lexeme_to_token($lexer, $1) }
-                | NEQ { lexeme_to_token($lexer, $1) }
-                | EQL_REGEX { lexeme_to_token($lexer, $1) }
-                | NEQ_REGEX { lexeme_to_token($lexer, $1) }
-                ;
+        |       NEQ { lexeme_to_token($lexer, $1) }
+        |       EQL_REGEX { lexeme_to_token($lexer, $1) }
+        |       NEQ_REGEX { lexeme_to_token($lexer, $1) }
+;
 
 /*
  * Literals.
@@ -540,26 +554,23 @@ number_literal -> Result<Expr, String>:
                         let num = parse_str_radix($lexer.span_str($span));
                         Ok(Expr::from(num?))
                 }
-                ;
+;
 
 string_literal -> Result<Expr, String>:
                 STRING { Ok(Expr::from(span_to_string($lexer, $span))) }
-                ;
+;
 
 duration -> Result<Duration, String>:
                 DURATION { parse_duration($lexer.span_str($span)) }
-                ;
+;
 
 /*
  * Wrappers for optional arguments.
  */
 maybe_duration -> Result<Option<Duration>, String>:
                 { Ok(None) }
-                | duration
-                {
-                        $1.map(Some)
-                }
-                ;
+        |       duration { $1.map(Some) }
+;
 
 %%
 

--- a/src/parser/promql.y
+++ b/src/parser/promql.y
@@ -417,6 +417,18 @@ label_matcher -> Result<Matcher, String>:
                         Err(format!("unexpected '{op}' in label matching, expected string"))
 
                 }
+                | IDENTIFIER match_op match_op STRING
+                {
+                        let op = $3?.val;
+                        Err(format!("unexpected '{op}' in label matching, expected string"))
+
+                }
+                | IDENTIFIER match_op match_op IDENTIFIER
+                {
+                        let op = $3?.val;
+                        Err(format!("unexpected '{op}' in label matching, expected string"))
+
+                }
                 | IDENTIFIER match_op IDENTIFIER
                 {
                         let id = lexeme_to_string($lexer, &$3)?;

--- a/src/parser/promql.y
+++ b/src/parser/promql.y
@@ -297,6 +297,10 @@ offset_expr -> Result<Expr, String>:
                 expr OFFSET duration { $1?.offset_expr(Offset::Pos($3?)) }
                 | expr OFFSET ADD duration { $1?.offset_expr(Offset::Pos($4?)) }
                 | expr OFFSET SUB duration { $1?.offset_expr(Offset::Neg($4?)) }
+                | expr OFFSET
+                {
+                        Err("unexpected end of input in offset, expected duration".into())
+                }
                 ;
 
 /*
@@ -331,6 +335,10 @@ matrix_selector -> Result<Expr, String>:
                 expr LEFT_BRACKET duration RIGHT_BRACKET
                 {
                         Expr::new_matrix_selector($1?, $3?)
+                }
+                | expr LEFT_BRACKET RIGHT_BRACKET
+                {
+                        Err("missing unit character in duration".into())
                 }
                 ;
 

--- a/src/parser/token.rs
+++ b/src/parser/token.rs
@@ -14,7 +14,6 @@
 
 use lazy_static::lazy_static;
 use std::collections::HashMap;
-use std::fmt::{self, Display};
 
 lrlex::lrlex_mod!("token_map");
 pub use token_map::*;
@@ -23,12 +22,6 @@ pub type TokenId = u8;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct TokenType(TokenId);
-
-impl Display for TokenType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "id: {}", self.0)
-    }
-}
 
 lazy_static! {
     static ref KEYWORDS: HashMap<&'static str, TokenId> =
@@ -180,12 +173,6 @@ pub fn get_keyword_token(s: &str) -> Option<TokenId> {
 pub struct Token {
     pub id: TokenType,
     pub val: String,
-}
-
-impl Display for Token {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "lexer token. id: {}, val: {}", self.id, self.val)
-    }
 }
 
 impl Token {

--- a/src/util/duration.rs
+++ b/src/util/duration.rs
@@ -91,7 +91,7 @@ pub fn parse_duration(ds: &str) -> Result<Duration, String> {
         .fold(Ok(Duration::ZERO), |acc, x| {
             acc.and_then(|d| {
                 d.checked_add(x.unwrap_or(Duration::ZERO))
-                    .ok_or("duration overflowed".into())
+                    .ok_or_else(|| "duration overflowed".into())
             })
         });
 

--- a/src/util/duration.rs
+++ b/src/util/duration.rs
@@ -91,7 +91,7 @@ pub fn parse_duration(ds: &str) -> Result<Duration, String> {
         .fold(Ok(Duration::ZERO), |acc, x| {
             acc.and_then(|d| {
                 d.checked_add(x.unwrap_or(Duration::ZERO))
-                    .ok_or_else(|| "duration overflowed".into())
+                    .ok_or("duration overflowed".into())
             })
         });
 


### PR DESCRIPTION
## what's included

- more test cases for failed scenario
- disable grmtools erros recovery, which will result in different result for same query
- re-format yacc file, especially for indent of `;` and `|`
- some test cases from prometheus official website

## why disable error recovery?

[error recovery](https://softdevteam.github.io/grmtools/master/book/errorrecovery.html) will try to repair the invalid promql, and it is unpredictable. Some queries are invalid, but sometimes they will be valid because of the repairing. In order to be stable, the repairing is to be disabled.