### PR TITLE
refactor: merge agg and match to LabelModifier

### DIFF
--- a/src/parser/function.rs
+++ b/src/parser/function.rs
@@ -264,7 +264,7 @@ lazy_static! {
 }
 
 /// get_function returns a predefined Function object for the given name.
-pub fn get_function(name: &str) -> Option<Function> {
+pub(crate) fn get_function(name: &str) -> Option<Function> {
     FUNCTIONS.get(name).cloned()
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -20,8 +20,8 @@
 //! Notes that in PromQL the parsed [`Expr`] is only a part of an query. It would also needs other
 //! parameters like "start"/"end" time or "step" time etc, which is included in [`EvalStmt`].
 
-mod ast;
-mod function;
+pub mod ast;
+pub mod function;
 pub mod lex;
 pub mod parse;
 pub mod production;
@@ -29,15 +29,14 @@ pub mod token;
 pub mod value;
 
 pub use ast::{
-    check_ast, AggModifier, AggregateExpr, AtModifier, BinModifier, BinaryExpr, Call, EvalStmt,
-    Expr, Extension, MatrixSelector, NumberLiteral, Offset, ParenExpr, StringLiteral, SubqueryExpr,
-    UnaryExpr, VectorMatchCardinality, VectorMatchModifier, VectorSelector,
+    AggregateExpr, AtModifier, BinModifier, BinaryExpr, Call, EvalStmt, Expr, Extension,
+    LabelModifier, MatrixSelector, NumberLiteral, Offset, ParenExpr, StringLiteral, SubqueryExpr,
+    UnaryExpr, VectorMatchCardinality, VectorSelector,
 };
 
-pub use function::{get_function, Function, FunctionArgs};
-pub use lex::{is_label, lexer, LexemeType};
+pub use function::{Function, FunctionArgs};
+pub use lex::{lexer, LexemeType};
 pub use parse::parse;
-pub use production::{lexeme_to_string, lexeme_to_token, span_to_string};
 pub use token::{Token, TokenId, TokenType};
 pub use value::{Value, ValueType};
 

--- a/src/parser/production.rs
+++ b/src/parser/production.rs
@@ -16,11 +16,14 @@ use crate::parser::{LexemeType, Token, TokenId};
 use lrpar::{Lexeme, NonStreamingLexer, Span};
 
 /// caller MUST pay attention to the index out of bounds issue
-pub fn span_to_string(lexer: &dyn NonStreamingLexer<LexemeType, TokenId>, span: Span) -> String {
+pub(crate) fn span_to_string(
+    lexer: &dyn NonStreamingLexer<LexemeType, TokenId>,
+    span: Span,
+) -> String {
     lexer.span_str(span).to_string()
 }
 
-pub fn lexeme_to_string(
+pub(crate) fn lexeme_to_string(
     lexer: &dyn NonStreamingLexer<LexemeType, TokenId>,
     lexeme: &Result<LexemeType, LexemeType>,
 ) -> Result<String, String> {
@@ -29,7 +32,7 @@ pub fn lexeme_to_string(
         .map_err(|_| "ParseError".into())
 }
 
-pub fn lexeme_to_token(
+pub(crate) fn lexeme_to_token(
     lexer: &dyn NonStreamingLexer<LexemeType, TokenId>,
     lexeme: Result<LexemeType, LexemeType>,
 ) -> Result<Token, String> {

--- a/src/parser/token.rs
+++ b/src/parser/token.rs
@@ -165,7 +165,7 @@ pub(crate) fn token_display(id: TokenId) -> &'static str {
 /// When changing this list, make sure to also change
 /// the maybe_label grammar rule in the generated parser
 /// to avoid misinterpretation of labels as keywords.
-pub fn get_keyword_token(s: &str) -> Option<TokenId> {
+pub(crate) fn get_keyword_token(s: &str) -> Option<TokenId> {
     KEYWORDS.get(s).copied()
 }
 


### PR DESCRIPTION
## what's included

- rename and merge AggModifier and VectorMatchModifier to LabelModifier
- hide some functions to crate level, not public

fix: #61 