### PR TITLE
fix: Convert Go regex to Rust regex

### DIFF
--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -896,6 +896,22 @@ mod tests {
                 ]);
                 Expr::new_vector_selector(None, matchers)
             }),
+            (r#"foo:bar{a=~"bc{9}"}"#, {
+                let matchers = Matchers::one(Matcher::new(
+                    MatchOp::Re(Regex::new("bc{9}").unwrap()),
+                    "a",
+                    "bc{9}",
+                ));
+                Expr::new_vector_selector(Some(String::from("foo:bar")), matchers)
+            }),
+            (r#"foo:bar{a=~"bc{abc}"}"#, {
+                let matchers = Matchers::one(Matcher::new(
+                    MatchOp::Re(Regex::new("bc\\{abc}").unwrap()),
+                    "a",
+                    "bc{abc}",
+                ));
+                Expr::new_vector_selector(Some(String::from("foo:bar")), matchers)
+            }),
         ];
         assert_cases(Case::new_result_cases(cases));
 


### PR DESCRIPTION
Go and Rust have some differences in their regex implementation. In Go the following is valid:

```
uri=~"/v[1-9]/.*/{gid}/{uid}"
```

Rust sees the `{gid}` as a bad repetition, it expects a range like {1,4}

```
regex parse error:
    /v[1-9]/.*/{gid}/{uid}
                ^
error: repetition quantifier expects a valid decimal
```

For it to be a valid Rust regex the opening { has to be escaped.

This change adds that escaping.

The implementation is simple, iteration + writing in a result buffer. It is probably not the best of nicest way of doing it, but it straight forward.

Fixes #75 