### PR TITLE
feat: add or operator for metric expression

### DIFF
--- a/src/label/mod.rs
+++ b/src/label/mod.rs
@@ -18,7 +18,7 @@ use std::collections::HashSet;
 use std::fmt;
 
 mod matcher;
-pub use matcher::{FilterActionType, MatchOp, Matcher, Matchers};
+pub use matcher::{MatchOp, Matcher, Matchers};
 
 /// "__name__"
 pub const METRIC_NAME: &str = "__name__";

--- a/src/label/mod.rs
+++ b/src/label/mod.rs
@@ -18,7 +18,7 @@ use std::collections::HashSet;
 use std::fmt;
 
 mod matcher;
-pub use matcher::{MatchOp, Matcher, Matchers};
+pub use matcher::{FilterActionType, MatchOp, Matcher, Matchers};
 
 /// "__name__"
 pub const METRIC_NAME: &str = "__name__";

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -564,6 +564,13 @@ impl Lexer {
         match self.pop() {
             Some('#') => State::LineComment,
             Some(',') => State::Lexeme(T_COMMA),
+            Some('o') => match self.peek() {
+                Some('r') => {
+                    self.pop();
+                    State::Lexeme(T_LOR)
+                }
+                _ => State::Identifier,
+            },
             Some(ch) if ch.is_ascii_whitespace() => State::Space,
             Some(ch) if is_alpha(ch) => State::Identifier,
             Some(ch) if STRING_SYMBOLS.contains(ch) => State::String(ch),

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -564,8 +564,8 @@ impl Lexer {
         match self.pop() {
             Some('#') => State::LineComment,
             Some(',') => State::Lexeme(T_COMMA),
-            Some('o') => {
-                if let Some('r') = self.peek() {
+            Some('o') | Some('O') => {
+                if let Some('r') | Some('R') = self.peek() {
                     self.pop();
                     if let Some(' ') = self.peek() {
                         State::Lexeme(T_LOR)

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -564,18 +564,18 @@ impl Lexer {
         match self.pop() {
             Some('#') => State::LineComment,
             Some(',') => State::Lexeme(T_COMMA),
-            Some('o') =>  {
-                if let Some('r') =  self.peek() {
+            Some('o') => {
+                if let Some('r') = self.peek() {
                     self.pop();
                     if let Some(' ') = self.peek() {
                         State::Lexeme(T_LOR)
-                    }  else {
+                    } else {
                         State::Identifier
                     }
                 } else {
                     State::Identifier
                 }
-            },
+            }
             Some(ch) if ch.is_ascii_whitespace() => State::Space,
             Some(ch) if is_alpha(ch) => State::Identifier,
             Some(ch) if STRING_SYMBOLS.contains(ch) => State::String(ch),

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -564,12 +564,17 @@ impl Lexer {
         match self.pop() {
             Some('#') => State::LineComment,
             Some(',') => State::Lexeme(T_COMMA),
-            Some('o') => match self.peek() {
-                Some('r') => {
+            Some('o') =>  {
+                if let Some('r') =  self.peek() {
                     self.pop();
-                    State::Lexeme(T_LOR)
+                    if let Some(' ') = self.peek() {
+                        State::Lexeme(T_LOR)
+                    }  else {
+                        State::Identifier
+                    }
+                } else {
+                    State::Identifier
                 }
-                _ => State::Identifier,
             },
             Some(ch) if ch.is_ascii_whitespace() => State::Space,
             Some(ch) if is_alpha(ch) => State::Identifier,

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -37,6 +37,7 @@ mod tests {
     use regex::Regex;
 
     use crate::label::{Labels, MatchOp, Matcher, Matchers, METRIC_NAME};
+    use crate::parser;
     use crate::parser::function::get_function;
     use crate::parser::{
         token, AtModifier as At, BinModifier, Expr, FunctionArgs, LabelModifier, Offset,
@@ -2119,48 +2120,81 @@ mod tests {
     #[test]
     fn test_or_filters() {
         let cases = vec![
+            (r#"foo{label1="1"}"#, {
+                let matchers = Matchers::new(vec![Matcher::new(MatchOp::Equal, "label1", "1")]);
+                Expr::new_vector_selector(Some(String::from("foo")), matchers)
+            }),
             (r#"foo{label1="1" or label2="2"}"#, {
-                let matchers = Matchers::new(vec![
+                let matchers = Matchers::new_or(vec![vec![
                     Matcher::new(MatchOp::Equal, "label1", "1"),
-                    Matcher::new_or(MatchOp::Equal, "label2", "2"),
-                ]);
+                    Matcher::new(MatchOp::Equal, "label2", "2"),
+                ]]);
                 Expr::new_vector_selector(Some(String::from("foo")), matchers)
             }),
             (r#"foo{label1="1" or or="or"}"#, {
-                let matchers = Matchers::new(vec![
+                let matchers = Matchers::new_or(vec![vec![
                     Matcher::new(MatchOp::Equal, "label1", "1"),
-                    Matcher::new_or(MatchOp::Equal, "or", "or"),
-                ]);
+                    Matcher::new(MatchOp::Equal, "or", "or"),
+                ]]);
                 Expr::new_vector_selector(Some(String::from("foo")), matchers)
             }),
             (r#"foo{label1="1" or label2="2" or label3="3"}"#, {
-                let matchers = Matchers::new(vec![
+                let matchers = Matchers::new_or(vec![vec![
                     Matcher::new(MatchOp::Equal, "label1", "1"),
-                    Matcher::new_or(MatchOp::Equal, "label2", "2"),
-                    Matcher::new_or(MatchOp::Equal, "label3", "3"),
-                ]);
+                    Matcher::new(MatchOp::Equal, "label2", "2"),
+                    Matcher::new(MatchOp::Equal, "label3", "3"),
+                ]]);
                 Expr::new_vector_selector(Some(String::from("foo")), matchers)
             }),
-            (r#"foo{label1="1" or label2="2" or label3="3" or label4="4"}"#, {
-                let matchers = Matchers::new(vec![
-                    Matcher::new(MatchOp::Equal, "label1", "1"),
-                    Matcher::new_or(MatchOp::Equal, "label2", "2"),
-                    Matcher::new_or(MatchOp::Equal, "label3", "3"),
-                    Matcher::new_or(MatchOp::Equal, "label4", "4"),
-                ]);
-                Expr::new_vector_selector(Some(String::from("foo")), matchers)
-            }),
+            (
+                r#"foo{label1="1" or label2="2" or label3="3" or label4="4"}"#,
+                {
+                    let matchers = Matchers::new_or(vec![vec![
+                        Matcher::new(MatchOp::Equal, "label1", "1"),
+                        Matcher::new(MatchOp::Equal, "label2", "2"),
+                        Matcher::new(MatchOp::Equal, "label3", "3"),
+                        Matcher::new(MatchOp::Equal, "label4", "4"),
+                    ]]);
+                    Expr::new_vector_selector(Some(String::from("foo")), matchers)
+                },
+            ),
         ];
         assert_cases(Case::new_result_cases(cases));
 
+        let promql = r#"a{label1="1" or label2="2"}"#;
+        let expected = r#"a{label1="1" or label2="2"}"#;
+        let expr = parser::parse(promql).unwrap();
+        assert_eq!(expr.to_string(), expected);
+
+        let promql = r#"a{label1="1", label2="2"}"#;
+        let expected = r#"a{label1="1",label2="2"}"#;
+        let expr = parser::parse(promql).unwrap();
+        assert_eq!(expr.to_string(), expected);
+
+        let promql = r#"a{label1="1", label2="2" or label3="3", label4="4"}"#;
+        let expected = r#"a{label1="1",label4="4",label2="2" or label3="3"}"#;
+        let expr = parser::parse(promql).unwrap();
+        assert_eq!(expr.to_string(), expected);
+
+        let promql = r#"a{label1="1", label2="2" or label3="3" or label4="4", label5="5"}"#;
+        let expected = r#"a{label1="1",label5="5",label2="2" or label3="3" or label4="4"}"#;
+        let expr = parser::parse(promql).unwrap();
+        assert_eq!(expr.to_string(), expected);
+
+        let promql = r#"a{label1="1" or label2="2" or label3="3" or label4="4"}"#;
+        let expected = r#"a{label1="1" or label2="2" or label3="3" or label4="4"}"#;
+        let expr = parser::parse(promql).unwrap();
+        assert_eq!(expr.to_string(), expected);
 
         let fail_cases = vec![
-            (r#"foo{or}"#, r#"invalid label matcher, expected label matching operator after 'or'"#),
+            (
+                r#"foo{or}"#,
+                r#"invalid label matcher, expected label matching operator after 'or'"#,
+            ),
             (r#"foo{label1="1" or}"#, INVALID_QUERY_INFO),
             (r#"foo{or label1="1"}"#, INVALID_QUERY_INFO),
             (r#"foo{label1="1" or or label2="2"}"#, INVALID_QUERY_INFO),
         ];
         assert_cases(Case::new_fail_cases(fail_cases));
-
     }
 }

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -2199,7 +2199,7 @@ mod tests {
         ];
         assert_cases(Case::new_result_cases(cases));
 
-        let display_cases = vec![
+        let display_cases = [
             r#"a{label1="1"}"#,
             r#"a{label1="1" or label2="2"}"#,
             r#"a{label1="1" or label2="2" or label3="3" or label4="4"}"#,
@@ -2210,7 +2210,7 @@ mod tests {
             .iter()
             .for_each(|expr| assert_eq!(parser::parse(expr).unwrap().to_string(), *expr));
 
-        let or_insensitive_cases = vec![
+        let or_insensitive_cases = [
             r#"a{label1="1" or label2="2"}"#,
             r#"a{label1="1" OR label2="2"}"#,
             r#"a{label1="1" Or label2="2"}"#,

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -2128,6 +2128,27 @@ mod tests {
                 ]);
                 Expr::new_vector_selector(Some(String::from("foo")), matchers)
             }),
+            (r#"foo{label1="1" OR label1="2"}"#, {
+                let matchers = Matchers::new(vec![]).with_or_matchers(vec![
+                    vec![Matcher::new(MatchOp::Equal, "label1", "1")],
+                    vec![Matcher::new(MatchOp::Equal, "label1", "2")],
+                ]);
+                Expr::new_vector_selector(Some(String::from("foo")), matchers)
+            }),
+            (r#"foo{label1="1" Or label1="2"}"#, {
+                let matchers = Matchers::new(vec![]).with_or_matchers(vec![
+                    vec![Matcher::new(MatchOp::Equal, "label1", "1")],
+                    vec![Matcher::new(MatchOp::Equal, "label1", "2")],
+                ]);
+                Expr::new_vector_selector(Some(String::from("foo")), matchers)
+            }),
+            (r#"foo{label1="1" oR label1="2"}"#, {
+                let matchers = Matchers::new(vec![]).with_or_matchers(vec![
+                    vec![Matcher::new(MatchOp::Equal, "label1", "1")],
+                    vec![Matcher::new(MatchOp::Equal, "label1", "2")],
+                ]);
+                Expr::new_vector_selector(Some(String::from("foo")), matchers)
+            }),
             (r#"foo{label1="1" or or="or"}"#, {
                 let matchers = Matchers::new(vec![]).with_or_matchers(vec![
                     vec![Matcher::new(MatchOp::Equal, "label1", "1")],
@@ -2178,25 +2199,16 @@ mod tests {
         ];
         assert_cases(Case::new_result_cases(cases));
 
-        let promql = r#"a{label1="1"}"#;
-        let expr = parser::parse(promql).unwrap();
-        assert_eq!(expr.to_string(), promql);
-
-        let promql = r#"a{label1="1" or label2="2"}"#;
-        let expr = parser::parse(promql).unwrap();
-        assert_eq!(expr.to_string(), promql);
-
-        let promql = r#"a{label1="1" or label2="2" or label3="3" or label4="4"}"#;
-        let expr = parser::parse(promql).unwrap();
-        assert_eq!(expr.to_string(), promql);
-
-        let promql = r#"a{label1="1", label2="2" or label3="3" or label4="4"}"#;
-        let expr = parser::parse(promql).unwrap();
-        assert_eq!(expr.to_string(), promql);
-
-        let promql = r#"a{label1="1", label2="2" or label3="3", label4="4"}"#;
-        let expr = parser::parse(promql).unwrap();
-        assert_eq!(expr.to_string(), promql);
+        let display_cases = vec![
+            r#"a{label1="1"}"#,
+            r#"a{label1="1" or label2="2"}"#,
+            r#"a{label1="1" or label2="2" or label3="3" or label4="4"}"#,
+            r#"a{label1="1", label2="2" or label3="3" or label4="4"}"#,
+            r#"a{label1="1", label2="2" or label3="3", label4="4"}"#,
+        ];
+        display_cases
+            .iter()
+            .for_each(|expr| assert_eq!(parser::parse(expr).unwrap().to_string(), *expr));
 
         let fail_cases = vec![
             (

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -37,7 +37,6 @@ mod tests {
     use regex::Regex;
 
     use crate::label::{Labels, MatchOp, Matcher, Matchers, METRIC_NAME};
-    use crate::parser;
     use crate::parser::function::get_function;
     use crate::parser::{
         token, AtModifier as At, BinModifier, Expr, FunctionArgs, LabelModifier, Offset,
@@ -2118,7 +2117,7 @@ mod tests {
     }
 
     #[test]
-    fn test_label_or() {
+    fn test_or_filters() {
         let cases = vec![
             (r#"foo{label1="1" or label2="2"}"#, {
                 let matchers = Matchers::new(vec![
@@ -2127,66 +2126,41 @@ mod tests {
                 ]);
                 Expr::new_vector_selector(Some(String::from("foo")), matchers)
             }),
-            (r#"foo{label1="1", label2="2"}"#, {
+            (r#"foo{label1="1" or or="or"}"#, {
                 let matchers = Matchers::new(vec![
                     Matcher::new(MatchOp::Equal, "label1", "1"),
-                    Matcher::new(MatchOp::Equal, "label2", "2"),
+                    Matcher::new_or(MatchOp::Equal, "or", "or"),
                 ]);
                 Expr::new_vector_selector(Some(String::from("foo")), matchers)
             }),
-            (r#"foo{label1="1" or label2="2", label3="3"}"#, {
+            (r#"foo{label1="1" or label2="2" or label3="3"}"#, {
                 let matchers = Matchers::new(vec![
                     Matcher::new(MatchOp::Equal, "label1", "1"),
                     Matcher::new_or(MatchOp::Equal, "label2", "2"),
-                    Matcher::new(MatchOp::Equal, "label3", "3"),
-                ]);
-                Expr::new_vector_selector(Some(String::from("foo")), matchers)
-            }),
-            (r#"foo{label1="1", label2="2" or label3="3"}"#, {
-                let matchers = Matchers::new(vec![
-                    Matcher::new(MatchOp::Equal, "label1", "1"),
-                    Matcher::new(MatchOp::Equal, "label2", "2"),
                     Matcher::new_or(MatchOp::Equal, "label3", "3"),
                 ]);
                 Expr::new_vector_selector(Some(String::from("foo")), matchers)
             }),
-            (
-                r#"foo{label1="1", label2="2" or label3="3", label4="4"}"#,
-                {
-                    let matchers = Matchers::new(vec![
-                        Matcher::new(MatchOp::Equal, "label1", "1"),
-                        Matcher::new(MatchOp::Equal, "label2", "2"),
-                        Matcher::new_or(MatchOp::Equal, "label3", "3"),
-                        Matcher::new(MatchOp::Equal, "label4", "4"),
-                    ]);
-                    Expr::new_vector_selector(Some(String::from("foo")), matchers)
-                },
-            ),
+            (r#"foo{label1="1" or label2="2" or label3="3" or label4="4"}"#, {
+                let matchers = Matchers::new(vec![
+                    Matcher::new(MatchOp::Equal, "label1", "1"),
+                    Matcher::new_or(MatchOp::Equal, "label2", "2"),
+                    Matcher::new_or(MatchOp::Equal, "label3", "3"),
+                    Matcher::new_or(MatchOp::Equal, "label4", "4"),
+                ]);
+                Expr::new_vector_selector(Some(String::from("foo")), matchers)
+            }),
         ];
         assert_cases(Case::new_result_cases(cases));
 
-        let promql = r#"a{on="1" or label2="2"}"#;
-        let expr = parser::parse(promql).unwrap();
-        assert_eq!(expr.to_string(), promql);
 
-        let promql = r#"a{label1="1",label2="2"}"#;
-        let expr = parser::parse(promql).unwrap();
-        assert_eq!(expr.to_string(), promql);
+        let fail_cases = vec![
+            (r#"foo{or}"#, r#"invalid label matcher, expected label matching operator after 'or'"#),
+            (r#"foo{label1="1" or}"#, INVALID_QUERY_INFO),
+            (r#"foo{or label1="1"}"#, INVALID_QUERY_INFO),
+            (r#"foo{label1="1" or or label2="2"}"#, INVALID_QUERY_INFO),
+        ];
+        assert_cases(Case::new_fail_cases(fail_cases));
 
-        let promql = r#"a{label1="1" or label2="2",label3="3"}"#;
-        let expr = parser::parse(promql).unwrap();
-        assert_eq!(expr.to_string(), promql);
-
-        let promql = r#"a{label1="1",label2="2" or label3="3"}"#;
-        let expr = parser::parse(promql).unwrap();
-        assert_eq!(expr.to_string(), promql);
-
-        let promql = r#"a{label1="1",label2="2" or label3="3",label4="4"}"#;
-        let expr = parser::parse(promql).unwrap();
-        assert_eq!(expr.to_string(), promql);
-
-        let promql = r#"a{o="1",o1="2" or o2="3",o3="4"}"#;
-        let expr = parser::parse(promql).unwrap();
-        assert_eq!(expr.to_string(), promql);
     }
 }

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -2210,6 +2210,20 @@ mod tests {
             .iter()
             .for_each(|expr| assert_eq!(parser::parse(expr).unwrap().to_string(), *expr));
 
+        let or_insensitive_cases = vec![
+            r#"a{label1="1" or label2="2"}"#,
+            r#"a{label1="1" OR label2="2"}"#,
+            r#"a{label1="1" Or label2="2"}"#,
+            r#"a{label1="1" oR label2="2"}"#,
+        ];
+
+        or_insensitive_cases.iter().for_each(|expr| {
+            assert_eq!(
+                parser::parse(expr).unwrap().to_string(),
+                r#"a{label1="1" or label2="2"}"#
+            )
+        });
+
         let fail_cases = vec![
             (
                 r#"foo{or}"#,

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -2179,29 +2179,24 @@ mod tests {
         assert_cases(Case::new_result_cases(cases));
 
         let promql = r#"a{label1="1"}"#;
-        let expected = r#"a{label1="1"}"#;
         let expr = parser::parse(promql).unwrap();
-        assert_eq!(expr.to_string(), expected);
+        assert_eq!(expr.to_string(), promql);
 
         let promql = r#"a{label1="1" or label2="2"}"#;
-        let expected = r#"a{label1="1" or label2="2"}"#;
         let expr = parser::parse(promql).unwrap();
-        assert_eq!(expr.to_string(), expected);
+        assert_eq!(expr.to_string(), promql);
 
         let promql = r#"a{label1="1" or label2="2" or label3="3" or label4="4"}"#;
-        let expected = r#"a{label1="1" or label2="2" or label3="3" or label4="4"}"#;
         let expr = parser::parse(promql).unwrap();
-        assert_eq!(expr.to_string(), expected);
+        assert_eq!(expr.to_string(), promql);
 
         let promql = r#"a{label1="1", label2="2" or label3="3" or label4="4"}"#;
-        let expected = r#"a{label1="1", label2="2" or label3="3" or label4="4"}"#;
         let expr = parser::parse(promql).unwrap();
-        assert_eq!(expr.to_string(), expected);
+        assert_eq!(expr.to_string(), promql);
 
         let promql = r#"a{label1="1", label2="2" or label3="3", label4="4"}"#;
-        let expected = r#"a{label1="1", label2="2" or label3="3", label4="4"}"#;
         let expr = parser::parse(promql).unwrap();
-        assert_eq!(expr.to_string(), expected);
+        assert_eq!(expr.to_string(), promql);
 
         let fail_cases = vec![
             (

--- a/src/parser/promql.y
+++ b/src/parser/promql.y
@@ -407,6 +407,7 @@ label_matchers -> Result<Matchers, String>:
 
 label_match_list -> Result<Matchers, String>:
                 label_match_list COMMA label_matcher { Ok($1?.append($3?)) }
+        |       label_match_list LOR label_matcher_or { Ok($1?.append($3?)) }
         |       label_matcher { Ok(Matchers::empty().append($1?)) }
 ;
 
@@ -416,6 +417,43 @@ label_matcher -> Result<Matcher, String>:
                         let name = lexeme_to_string($lexer, &$1)?;
                         let value = lexeme_to_string($lexer, &$3)?;
                         Matcher::new_matcher($2?.id(), name, value)
+                }
+        |       IDENTIFIER match_op match_op
+                {
+                        let op = $3?.val;
+                        Err(format!("unexpected '{op}' in label matching, expected string"))
+
+                }
+        |       IDENTIFIER match_op match_op STRING
+                {
+                        let op = $3?.val;
+                        Err(format!("unexpected '{op}' in label matching, expected string"))
+
+                }
+        |       IDENTIFIER match_op match_op IDENTIFIER
+                {
+                        let op = $3?.val;
+                        Err(format!("unexpected '{op}' in label matching, expected string"))
+
+                }
+        |       IDENTIFIER match_op IDENTIFIER
+                {
+                        let id = lexeme_to_string($lexer, &$3)?;
+                        Err(format!("unexpected identifier '{id}' in label matching, expected string"))
+                }
+        |       IDENTIFIER
+                {
+                        let id = lexeme_to_string($lexer, &$1)?;
+                        Err(format!("invalid label matcher, expected label matching operator after '{id}'"))
+                }
+;
+
+label_matcher_or -> Result<Matcher, String>:
+                IDENTIFIER match_op STRING
+                {
+                        let name = lexeme_to_string($lexer, &$1)?;
+                        let value = lexeme_to_string($lexer, &$3)?;
+                        Matcher::new_matcher_or($2?.id(), name, value)
                 }
         |       IDENTIFIER match_op match_op
                 {

--- a/src/parser/promql.y
+++ b/src/parser/promql.y
@@ -407,7 +407,7 @@ label_matchers -> Result<Matchers, String>:
 
 label_match_list -> Result<Matchers, String>:
                 label_match_list COMMA label_matcher { Ok($1?.append($3?)) }
-        |       label_match_list LOR label_matcher_or { Ok($1?.append($3?)) }
+        |       label_match_list LOR label_matcher { Ok($1?.append_or($3?)) }
         |       label_matcher { Ok(Matchers::empty().append($1?)) }
 ;
 
@@ -417,43 +417,6 @@ label_matcher -> Result<Matcher, String>:
                         let name = lexeme_to_string($lexer, &$1)?;
                         let value = lexeme_to_string($lexer, &$3)?;
                         Matcher::new_matcher($2?.id(), name, value)
-                }
-        |       IDENTIFIER match_op match_op
-                {
-                        let op = $3?.val;
-                        Err(format!("unexpected '{op}' in label matching, expected string"))
-
-                }
-        |       IDENTIFIER match_op match_op STRING
-                {
-                        let op = $3?.val;
-                        Err(format!("unexpected '{op}' in label matching, expected string"))
-
-                }
-        |       IDENTIFIER match_op match_op IDENTIFIER
-                {
-                        let op = $3?.val;
-                        Err(format!("unexpected '{op}' in label matching, expected string"))
-
-                }
-        |       IDENTIFIER match_op IDENTIFIER
-                {
-                        let id = lexeme_to_string($lexer, &$3)?;
-                        Err(format!("unexpected identifier '{id}' in label matching, expected string"))
-                }
-        |       IDENTIFIER
-                {
-                        let id = lexeme_to_string($lexer, &$1)?;
-                        Err(format!("invalid label matcher, expected label matching operator after '{id}'"))
-                }
-;
-
-label_matcher_or -> Result<Matcher, String>:
-                IDENTIFIER match_op STRING
-                {
-                        let name = lexeme_to_string($lexer, &$1)?;
-                        let value = lexeme_to_string($lexer, &$3)?;
-                        Matcher::new_matcher_or($2?.id(), name, value)
                 }
         |       IDENTIFIER match_op match_op
                 {


### PR DESCRIPTION
[**MetricQL**](https://docs.victoriametrics.com/keyconcepts/#metricsql) is an enhanced extension of **PromQL**, And is backward-compatible with **PromQL**.

Currently, **MetricQL** already supports using the "**or**" operator to connect label filters as follows:
For example, the following query selects time series with {job="app1",env="prod"} or {job="app2",env="dev"} labels:
> `{job="app1",env="prod" or job="app2",env="dev"}`

A more detailed description of this feature can be found here [MetricsQL filtering-by-multiple-or-filters](https://docs.victoriametrics.com/keyconcepts/#filtering-by-multiple-or-filters)

This PR is to support filtering by multiple “or” filters
