### PR TITLE
fix: handle `Expr::Binary` properly in `walk_expr`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ let promql = r#"
 
 match parser::parse(promql) {
     Ok(expr) => {
-        println!("Prettify:\n\n{}", expr.prettify());
+        println!("Prettify:\n{}\n", expr.prettify());
         println!("AST:\n{expr:?}");
     }
     Err(info) => println!("Err: {info:?}"),

--- a/examples/parser.rs
+++ b/examples/parser.rs
@@ -24,7 +24,7 @@ fn main() {
 
     match parser::parse(promql) {
         Ok(expr) => {
-            println!("Prettify:\n\n{}", expr.prettify());
+            println!("Prettify:\n{}\n", expr.prettify());
             println!("AST:\n{expr:?}");
         }
         Err(info) => println!("Err: {info:?}"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! match parser::parse(promql) {
 //!     Ok(expr) => {
-//!         println!("Prettify:\n\n{}", expr.prettify());
+//!         println!("Prettify:\n{}\n", expr.prettify());
 //!         println!("AST:\n{expr:?}");
 //!     }
 //!     Err(info) => println!("Err: {info:?}"),

--- a/src/util/visitor.rs
+++ b/src/util/visitor.rs
@@ -47,7 +47,7 @@ pub fn walk_expr<V: ExprVisitor>(visitor: &mut V, expr: &Expr) -> Result<bool, V
         Expr::Aggregate(AggregateExpr { expr, .. }) => walk_expr(visitor, expr)?,
         Expr::Unary(UnaryExpr { expr }) => walk_expr(visitor, expr)?,
         Expr::Binary(BinaryExpr { lhs, rhs, .. }) => {
-            walk_expr(visitor, lhs)? || walk_expr(visitor, rhs)?
+            walk_expr(visitor, lhs)? && walk_expr(visitor, rhs)?
         }
         Expr::Paren(ParenExpr { expr }) => walk_expr(visitor, expr)?,
         Expr::Subquery(SubqueryExpr { expr, .. }) => walk_expr(visitor, expr)?,

--- a/src/util/visitor.rs
+++ b/src/util/visitor.rs
@@ -200,10 +200,16 @@ mod tests {
             namespace: "sample".to_string(),
         };
 
-        let ast = parser::parse("pg_stat_activity_count{namespace=\"sample\"} + pg_stat_activity_count{}").unwrap();
+        let ast = parser::parse(
+            "pg_stat_activity_count{namespace=\"sample\"} + pg_stat_activity_count{}",
+        )
+        .unwrap();
         assert!(!walk_expr(&mut visitor, &ast).unwrap());
 
-        let ast = parser::parse("pg_stat_activity_count{} - pg_stat_activity_count{namespace=\"sample\"}").unwrap();
+        let ast = parser::parse(
+            "pg_stat_activity_count{} - pg_stat_activity_count{namespace=\"sample\"}",
+        )
+        .unwrap();
         assert!(!walk_expr(&mut visitor, &ast).unwrap());
 
         let ast = parser::parse("pg_stat_activity_count{} * pg_stat_activity_count{}").unwrap();

--- a/src/util/visitor.rs
+++ b/src/util/visitor.rs
@@ -193,4 +193,29 @@ mod tests {
         let ast = parser::parse(r#""1""#).unwrap();
         assert!(!walk_expr(&mut visitor, &ast).unwrap());
     }
+
+    #[test]
+    fn test_binary_expr() {
+        let mut visitor = NamespaceVisitor {
+            namespace: "sample".to_string(),
+        };
+
+        let ast = parser::parse("pg_stat_activity_count{namespace=\"sample\"} + pg_stat_activity_count{}").unwrap();
+        assert!(!walk_expr(&mut visitor, &ast).unwrap());
+
+        let ast = parser::parse("pg_stat_activity_count{} - pg_stat_activity_count{namespace=\"sample\"}").unwrap();
+        assert!(!walk_expr(&mut visitor, &ast).unwrap());
+
+        let ast = parser::parse("pg_stat_activity_count{} * pg_stat_activity_count{}").unwrap();
+        assert!(!walk_expr(&mut visitor, &ast).unwrap());
+
+        let ast = parser::parse("pg_stat_activity_count{namespace=\"sample\"} / 1").unwrap();
+        assert!(!walk_expr(&mut visitor, &ast).unwrap());
+
+        let ast = parser::parse("1 % pg_stat_activity_count{namespace=\"sample\"}").unwrap();
+        assert!(!walk_expr(&mut visitor, &ast).unwrap());
+
+        let ast = parser::parse("pg_stat_activity_count{namespace=\"sample\"} ^ pg_stat_activity_count{namespace=\"sample\"}").unwrap();
+        assert!(walk_expr(&mut visitor, &ast).unwrap());
+    }
 }


### PR DESCRIPTION
When handling `Expr::Binary` in `walk_expr`, the return values from lhs and rhs are ORed (`||`) but it should be `&&`.

For example, let the expression be `foo{l1="v1"} + bar{l2="v2"}`. `walk_expr` will recurse into lhs (`foo`) first and if the return value is `Ok(true)`, it should recurse into rhs (`bar`) but it would not.

Additionally, there was a small inconsistency in the example (newlines between the output), so I fixed it.