### PR TITLE
refactor: implement `Display` for `EvalStmt`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ categories = ["parser-implementations"]
 
 [dependencies]
 cfgrammar = "0.13.5"
+chrono = "0.4.38"
 lazy_static = "1.4.0"
 lrlex = "0.13.5"
 lrpar = "0.13.5"

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -36,9 +36,10 @@ use std::time::{Duration, SystemTime};
 /// # Vector Match Modifier
 ///
 /// - Exclude means `without` removes the listed labels from the result vector,
-/// while all other labels are preserved in the output.
+///   while all other labels are preserved in the output.
+///
 /// - Include means `by` does the opposite and drops labels that are not listed in the by clause,
-/// even if their label values are identical between all elements of the vector.
+///   even if their label values are identical between all elements of the vector.
 ///
 /// if empty listed labels, meaning no grouping
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -321,11 +321,12 @@ impl fmt::Display for EvalStmt {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "[{}] @ [{}, {}, {}]",
+            "[{}] @ [{}, {}, {}, {}]",
             self.expr,
             DateTime::<Utc>::from(self.start).to_rfc3339(),
             DateTime::<Utc>::from(self.end).to_rfc3339(),
-            display_duration(&self.interval)
+            display_duration(&self.interval),
+            display_duration(&self.lookback_delta)
         )
     }
 }
@@ -2461,7 +2462,7 @@ or
         let query = r#"http_requests_total{job="apiserver", handler="/api/comments"}[5m]"#;
         let start = "2024-10-08T07:15:00.022978+00:00";
         let end = "2024-10-08T07:15:30.012978+00:00";
-        let expect = r#"[http_requests_total{handler="/api/comments",job="apiserver"}[5m]] @ [2024-10-08T07:15:00.022978+00:00, 2024-10-08T07:15:30.012978+00:00, 1m]"#;
+        let expect = r#"[http_requests_total{handler="/api/comments",job="apiserver"}[5m]] @ [2024-10-08T07:15:00.022978+00:00, 2024-10-08T07:15:30.012978+00:00, 1m, 5m]"#;
 
         let stmt = EvalStmt {
             expr: crate::parser::parse(query).unwrap(),


### PR DESCRIPTION
## What's changed

Implement `fmt::Display` for `EvalStmt` for better logging.