### PR TITLE
feat: serialize AST to json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,14 @@ lazy_static = "1.4.0"
 lrlex = "0.13.5"
 lrpar = "0.13.5"
 regex = "1"
+serde = { version = "1", optional = true }
+
+[features]
+default = []
+ser = ["serde"]
+
+[dev-dependencies]
+serde_json = "1"
 
 [build-dependencies]
 cfgrammar = "0.13.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,13 +32,11 @@ lrlex = "0.13.5"
 lrpar = "0.13.5"
 regex = "1"
 serde = { version = "1", optional = true }
+serde_json = { version = "1", optional = true }
 
 [features]
 default = []
-ser = ["serde"]
-
-[dev-dependencies]
-serde_json = "1"
+ser = ["serde", "serde_json"]
 
 [build-dependencies]
 cfgrammar = "0.13.5"

--- a/src/label/matcher.rs
+++ b/src/label/matcher.rs
@@ -204,6 +204,7 @@ fn try_escape_for_repeat_re(re: &str) -> String {
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct Matchers {
     pub matchers: Vec<Matcher>,
+    #[cfg_attr(feature = "ser", serde(skip_serializing_if = "<[_]>::is_empty"))]
     pub or_matchers: Vec<Vec<Matcher>>,
 }
 

--- a/src/label/matcher.rs
+++ b/src/label/matcher.rs
@@ -71,12 +71,7 @@ impl serde::Serialize for MatchOp {
     where
         S: serde::Serializer,
     {
-        match self {
-            MatchOp::Equal => serializer.serialize_str("="),
-            MatchOp::NotEqual => serializer.serialize_str("=~"),
-            MatchOp::Re(_reg) => serializer.serialize_str("=~"),
-            MatchOp::NotRe(_reg) => serializer.serialize_str("!~"),
-        }
+        serializer.serialize_str(&self.to_string())
     }
 }
 

--- a/src/label/mod.rs
+++ b/src/label/mod.rs
@@ -32,6 +32,7 @@ pub const INSTANCE_NAME: &str = "instance";
 pub type Label = String;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct Labels {
     pub labels: Vec<Label>,
 }

--- a/src/label/mod.rs
+++ b/src/label/mod.rs
@@ -32,7 +32,6 @@ pub const INSTANCE_NAME: &str = "instance";
 pub type Label = String;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct Labels {
     pub labels: Vec<Label>,
 }
@@ -71,6 +70,23 @@ impl Labels {
 impl fmt::Display for Labels {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.labels.join(", "))
+    }
+}
+
+#[cfg(feature = "ser")]
+impl serde::Serialize for Labels {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeSeq;
+        let mut seq = serializer.serialize_seq(Some(self.labels.len()))?;
+
+        for l in &self.labels {
+            seq.serialize_element(&l)?;
+        }
+
+        seq.end()
     }
 }
 

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -264,7 +264,8 @@ pub enum Offset {
 }
 
 impl Offset {
-    pub fn value_millis(&self) -> i128 {
+    #[cfg(feature = "ser")]
+    pub(crate) fn as_millis(&self) -> i128 {
         match self {
             Self::Pos(dur) => dur.as_millis() as i128,
             Self::Neg(dur) => -(dur.as_millis() as i128),
@@ -272,11 +273,14 @@ impl Offset {
     }
 
     #[cfg(feature = "ser")]
-    pub fn serialize_offset<S>(offset: &Option<Self>, serializer: S) -> Result<S::Ok, S::Error>
+    pub(crate) fn serialize_offset<S>(
+        offset: &Option<Self>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
-        let value = offset.as_ref().map(|o| o.value_millis()).unwrap_or(0);
+        let value = offset.as_ref().map(|o| o.as_millis()).unwrap_or(0);
         serializer.serialize_i128(value)
     }
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -43,6 +43,7 @@ use std::time::{Duration, SystemTime};
 ///
 /// if empty listed labels, meaning no grouping
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub enum LabelModifier {
     Include(Labels),
     Exclude(Labels),
@@ -72,6 +73,7 @@ impl LabelModifier {
 /// The label list provided with the group_left or group_right modifier contains
 /// additional labels from the "one"-side to be included in the result metrics.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub enum VectorMatchCardinality {
     OneToOne,
     ManyToOne(Labels),
@@ -100,6 +102,7 @@ impl VectorMatchCardinality {
 
 /// Binary Expr Modifier
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct BinModifier {
     /// The matching behavior for the operation if both operands are Vectors.
     /// If they are not this field is None.
@@ -211,7 +214,19 @@ impl fmt::Display for Offset {
         }
     }
 }
+
+#[cfg(feature = "ser")]
+impl serde::Serialize for Offset {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&format!("{}", self))
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub enum AtModifier {
     Start,
     End,
@@ -339,6 +354,7 @@ impl fmt::Display for EvalStmt {
 ///
 /// parameter is only required for `count_values`, `quantile`, `topk` and `bottomk`.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct AggregateExpr {
     /// The used aggregation operation.
     pub op: TokenType,
@@ -393,6 +409,7 @@ impl Prettier for AggregateExpr {
 
 /// UnaryExpr will negate the expr
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct UnaryExpr {
     pub expr: Box<Expr>,
 }
@@ -421,6 +438,7 @@ impl Prettier for UnaryExpr {
 /// <vector expr> <bin-op> on(<label list>) group_right(<label list>) <vector expr>
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct BinaryExpr {
     /// The operation of the expression.
     pub op: TokenType,
@@ -490,6 +508,7 @@ impl Prettier for BinaryExpr {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct ParenExpr {
     pub expr: Box<Expr>,
 }
@@ -516,6 +535,7 @@ impl Prettier for ParenExpr {
 /// <instant_query> '[' <range> ':' [<resolution>] ']' [ @ <float_literal> ] [ offset <duration> ]
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct SubqueryExpr {
     pub expr: Box<Expr>,
     pub offset: Option<Offset>,
@@ -563,6 +583,7 @@ impl Prettier for SubqueryExpr {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct NumberLiteral {
     pub val: f64,
 }
@@ -610,6 +631,7 @@ impl Prettier for NumberLiteral {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct StringLiteral {
     pub val: String,
 }
@@ -627,10 +649,13 @@ impl Prettier for StringLiteral {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct VectorSelector {
     pub name: Option<String>,
+    #[cfg_attr(feature = "ser", serde(flatten))]
     pub matchers: Matchers,
     pub offset: Option<Offset>,
+    // TODO: special handling for ser
     pub at: Option<AtModifier>,
 }
 
@@ -727,6 +752,7 @@ impl Prettier for VectorSelector {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct MatrixSelector {
     pub vs: VectorSelector,
     pub range: Duration,
@@ -803,6 +829,7 @@ impl Prettier for MatrixSelector {
 ///  - tan()
 ///  - tanh()
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct Call {
     pub func: Function,
     pub args: FunctionArgs,
@@ -852,6 +879,8 @@ impl PartialEq for Extension {
 impl Eq for Extension {}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "ser", derive(serde::Serialize))]
+#[cfg_attr(feature = "ser", serde(tag = "type", rename_all = "camelCase"))]
 pub enum Expr {
     /// Aggregate represents an aggregation operation on a Vector.
     Aggregate(AggregateExpr),
@@ -887,6 +916,7 @@ pub enum Expr {
 
     /// Extension represents an extension expression. It is for user to attach additional
     /// information to the AST. This parser won't generate Extension node.
+    #[cfg_attr(feature = "ser", serde(skip))]
     Extension(Extension),
 }
 

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -655,8 +655,16 @@ pub struct SubqueryExpr {
     pub offset: Option<Offset>,
     #[cfg_attr(feature = "ser", serde(flatten))]
     pub at: Option<AtModifier>,
+    #[cfg_attr(
+        feature = "ser",
+        serde(serialize_with = "crate::util::duration::serialize_duration")
+    )]
     pub range: Duration,
     /// Default is the global evaluation interval.
+    #[cfg_attr(
+        feature = "ser",
+        serde(serialize_with = "crate::util::duration::serialize_duration_opt")
+    )]
     pub step: Option<Duration>,
 }
 
@@ -1036,7 +1044,6 @@ pub enum Expr {
     Paren(ParenExpr),
 
     /// SubqueryExpr represents a subquery.
-    #[cfg_attr(feature = "ser", serde(rename = "subqueryExpr"))]
     Subquery(SubqueryExpr),
 
     /// NumberLiteral represents a number.

--- a/src/parser/function.rs
+++ b/src/parser/function.rs
@@ -80,9 +80,14 @@ impl Prettier for FunctionArgs {
 /// Functions is a list of all functions supported by PromQL, including their types.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
+#[cfg_attr(feature = "ser", serde(rename_all = "camelCase"))]
 pub struct Function {
     pub name: &'static str,
     pub arg_types: Vec<ValueType>,
+    #[cfg_attr(
+        feature = "ser",
+        serde(serialize_with = "Function::serialize_variadic")
+    )]
     pub variadic: bool,
     pub return_type: ValueType,
 }
@@ -99,6 +104,18 @@ impl Function {
             arg_types,
             variadic,
             return_type,
+        }
+    }
+
+    #[cfg(feature = "ser")]
+    pub fn serialize_variadic<S>(variadic: &bool, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if *variadic {
+            serializer.serialize_i8(1)
+        } else {
+            serializer.serialize_i8(0)
         }
     }
 }

--- a/src/parser/function.rs
+++ b/src/parser/function.rs
@@ -108,7 +108,7 @@ impl Function {
     }
 
     #[cfg(feature = "ser")]
-    pub fn serialize_variadic<S>(variadic: &bool, serializer: S) -> Result<S::Ok, S::Error>
+    pub(crate) fn serialize_variadic<S>(variadic: &bool, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {

--- a/src/parser/function.rs
+++ b/src/parser/function.rs
@@ -23,6 +23,7 @@ use crate::util::join_vector;
 
 /// called by func in Call
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct FunctionArgs {
     pub args: Vec<Box<Expr>>,
 }
@@ -78,6 +79,7 @@ impl Prettier for FunctionArgs {
 
 /// Functions is a list of all functions supported by PromQL, including their types.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct Function {
     pub name: &'static str,
     pub arg_types: Vec<ValueType>,

--- a/src/parser/token.rs
+++ b/src/parser/token.rs
@@ -22,6 +22,7 @@ pub use token_map::*;
 pub type TokenId = u8;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct TokenType(TokenId);
 
 lazy_static! {

--- a/src/parser/token.rs
+++ b/src/parser/token.rs
@@ -22,8 +22,17 @@ pub use token_map::*;
 pub type TokenId = u8;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct TokenType(TokenId);
+
+#[cfg(feature = "ser")]
+impl serde::Serialize for TokenType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(token_display(self.0))
+    }
+}
 
 lazy_static! {
     static ref KEYWORDS: HashMap<&'static str, TokenId> =

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -15,6 +15,7 @@
 use std::fmt::{self, Display};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub enum ValueType {
     Vector,
     Scalar,

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -16,6 +16,7 @@ use std::fmt::{self, Display};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
+#[cfg_attr(feature = "ser", serde(rename_all = "camelCase"))]
 pub enum ValueType {
     Vector,
     Scalar,

--- a/src/util/duration.rs
+++ b/src/util/duration.rs
@@ -135,6 +135,15 @@ pub fn display_duration(duration: &Duration) -> String {
     ss
 }
 
+#[cfg(feature = "ser")]
+pub fn serialize_duration<S>(dur: &Duration, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let duration_millis = dur.as_millis();
+    serializer.serialize_u128(duration_millis)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/util/duration.rs
+++ b/src/util/duration.rs
@@ -144,6 +144,18 @@ where
     serializer.serialize_u128(duration_millis)
 }
 
+#[cfg(feature = "ser")]
+pub fn serialize_duration_opt<S>(dur: &Option<Duration>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    if let Some(dur) = dur {
+        serialize_duration(dur, serializer)
+    } else {
+        serializer.serialize_none()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/util/duration.rs
+++ b/src/util/duration.rs
@@ -136,7 +136,7 @@ pub fn display_duration(duration: &Duration) -> String {
 }
 
 #[cfg(feature = "ser")]
-pub fn serialize_duration<S>(dur: &Duration, serializer: S) -> Result<S::Ok, S::Error>
+pub(crate) fn serialize_duration<S>(dur: &Duration, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {
@@ -145,7 +145,10 @@ where
 }
 
 #[cfg(feature = "ser")]
-pub fn serialize_duration_opt<S>(dur: &Option<Duration>, serializer: S) -> Result<S::Ok, S::Error>
+pub(crate) fn serialize_duration_opt<S>(
+    dur: &Option<Duration>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -382,4 +382,47 @@ fn test_serialize() {
             "type": "binaryExpr"
         }
     );
+
+    assert_json_ser_eq!("min_over_time( rate(http_requests_total[5m])[30m:1m] )",
+        {
+            "args": [
+                {
+                    "expr": {
+                        "args": [
+                            {
+                                "matchers": [],
+                                "name": "http_requests_total",
+                                "offset": 0,
+                                "range": 300000,
+                                "type": "matrixSelector"
+                            }
+                        ],
+                        "func": {
+                            "argTypes": [
+                                "matrix"
+                            ],
+                            "name": "rate",
+                            "returnType": "vector",
+                            "variadic": 0
+                        },
+                        "type": "call"
+                    },
+                    "offset": 0,
+                    "range": 1800000,
+                    "step": 60000,
+                    "type": "subquery"
+                }
+            ],
+            "func": {
+                "argTypes": [
+                    "matrix"
+                ],
+                "name": "min_over_time",
+                "returnType": "vector",
+                "variadic": 0
+            },
+            "type": "call"
+
+    }
+        );
 }

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -51,6 +51,30 @@ fn test_serialize() {
     });
 
     assert_json_ser_eq!(
+        "prometheus_tsdb_wal_writes_failed_total offset -2s @ end()",
+
+    {
+        "matchers": [],
+        "name": "prometheus_tsdb_wal_writes_failed_total",
+        "offset": -2000,
+        "startOrEnd": "end",
+        "timestamp": null,
+        "type": "vectorSelector"
+    });
+
+    assert_json_ser_eq!(
+        "prometheus_tsdb_wal_writes_failed_total @ 1000",
+
+    {
+        "matchers": [],
+        "name": "prometheus_tsdb_wal_writes_failed_total",
+        "offset": 0,
+        "startOrEnd": null,
+        "timestamp": 1000000,
+        "type": "vectorSelector"
+    });
+
+    assert_json_ser_eq!(
             "rate(prometheus_tsdb_wal_writes_failed_total{instance = \"localhost:9090\"}[1m])",
 
     {

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -20,8 +20,8 @@ macro_rules! assert_json_ser_eq {
     ($promql: literal, $json: tt) => {
         let ast = parse($promql).expect("Failed to parse");
         assert_eq!(
-            serde_json::json!($json),
-            serde_json::to_value(ast).expect("Failed to serialize")
+            serde_json::to_value(ast).expect("Failed to serialize"),
+            serde_json::json!($json)
         );
     };
 }
@@ -104,5 +104,178 @@ fn test_serialize() {
         "type": "call"
     }
 
+    );
+
+    assert_json_ser_eq!("\"yes\"",
+    {
+        "type": "stringLiteral",
+        "val": "yes"
+    }
+    );
+
+    assert_json_ser_eq!("1",
+    {
+        "type": "numberLiteral",
+        "val": "1"
+    }
+    );
+
+    assert_json_ser_eq!("1+1",
+    {
+        "bool": false,
+        "lhs": {
+            "type": "numberLiteral",
+            "val": "1"
+        },
+        "op": "+",
+        "matching": null,
+        "rhs": {
+            "type": "numberLiteral",
+            "val": "1"
+        },
+        "type": "binaryExpr"
+    }
+    );
+
+    assert_json_ser_eq!("- process_cpu_seconds_total",
+        {
+            "expr": {
+                "matchers": [],
+                "name": "process_cpu_seconds_total",
+                "offset": 0,
+                "type": "vectorSelector"
+            },
+            "op": "-",
+            "type": "unaryExpr"
+        }
+    );
+
+    assert_json_ser_eq!(r#"1 - ((node_memory_MemAvailable_bytes{job="node"} or (node_memory_Buffers_bytes{job="node"} + node_memory_Cached_bytes{job="node"} + node_memory_MemFree_bytes{job="node"} + node_memory_Slab_bytes{job="node"}) ) / node_memory_MemTotal_bytes{job="node"})"#,
+        {
+            "bool": false,
+            "lhs": {
+                "type": "numberLiteral",
+                "val": "1"
+            },
+            "op": "-",
+            "matching": null,
+            "rhs": {
+                "expr": {
+                    "bool": false,
+                    "lhs": {
+                        "expr": {
+                            "bool": false,
+                            "lhs": {
+                                "matchers": [
+                                    {
+                                        "name": "job",
+                                        "type": "=",
+                                        "value": "node"
+                                    }
+                                ],
+                                "name": "node_memory_MemAvailable_bytes",
+                                "offset": 0,
+                                "type": "vectorSelector"
+                            },
+                            "matching": {
+                                "card": "many-to-many",
+                                "include": [],
+                                "labels": [],
+                                "on": false
+                            },
+                            "op": "or",
+                            "rhs": {
+                                "expr": {
+                                    "bool": false,
+                                    "lhs": {
+                                        "bool": false,
+                                        "lhs": {
+                                            "bool": false,
+                                            "lhs": {
+                                                "matchers": [
+                                                    {
+                                                        "name": "job",
+                                                        "type": "=",
+                                                        "value": "node"
+                                                    }
+                                                ],
+                                                "name": "node_memory_Buffers_bytes",
+                                                "offset": 0,
+                                                "type": "vectorSelector"
+                                            },
+                                            "matching": null,
+                                            "op": "+",
+                                            "rhs": {
+                                                "matchers": [
+                                                    {
+                                                        "name": "job",
+                                                        "type": "=",
+                                                        "value": "node"
+                                                    }
+                                                ],
+                                                "name": "node_memory_Cached_bytes",
+                                                "offset": 0,
+                                                "type": "vectorSelector"
+                                            },
+                                            "type": "binaryExpr"
+                                        },
+                                        "matching": null,
+                                        "op": "+",
+                                        "rhs": {
+                                            "matchers": [
+                                                {
+                                                    "name": "job",
+                                                    "type": "=",
+                                                    "value": "node"
+                                                }
+                                            ],
+                                            "name": "node_memory_MemFree_bytes",
+                                            "offset": 0,
+                                            "type": "vectorSelector"
+                                        },
+                                        "type": "binaryExpr"
+                                    },
+                                    "matching": null,
+                                    "op": "+",
+                                    "rhs": {
+                                        "matchers": [
+                                            {
+                                                "name": "job",
+                                                "type": "=",
+                                                "value": "node"
+                                            }
+                                        ],
+                                        "name": "node_memory_Slab_bytes",
+                                        "offset": 0,
+                                        "type": "vectorSelector"
+                                    },
+                                    "type": "binaryExpr"
+                                },
+                                "type": "parenExpr"
+                            },
+                            "type": "binaryExpr"
+                        },
+                        "type": "parenExpr"
+                    },
+                    "matching": null,
+                    "op": "/",
+                    "rhs": {
+                        "matchers": [
+                            {
+                                "name": "job",
+                                "type": "=",
+                                "value": "node"
+                            }
+                        ],
+                        "name": "node_memory_MemTotal_bytes",
+                        "offset": 0,
+                        "type": "vectorSelector"
+                    },
+                    "type": "binaryExpr"
+                },
+                "type": "parenExpr"
+            },
+            "type": "binaryExpr"
+        }
     );
 }

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #![cfg(feature = "ser")]
 
 use promql_parser::parser::parse;

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -1,0 +1,47 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#![cfg(feature = "ser")]
+
+use promql_parser::parser::parse;
+
+macro_rules! assert_json_ser_eq {
+    ($promql: literal, $json: tt) => {
+        let ast = parse($promql).expect("Failed to parse");
+        assert_eq!(
+            serde_json::json!($json),
+            serde_json::to_value(ast).expect("Failed to serialize")
+        );
+    };
+}
+
+#[test]
+fn test_serialize() {
+    assert_json_ser_eq!(
+        "prometheus_tsdb_wal_writes_failed_total",
+
+    {
+    "matchers": [
+      {
+        "name": "__name__",
+        "type": "=",
+        "value": "prometheus_tsdb_wal_writes_failed_total"
+      }
+    ],
+    "name": "prometheus_tsdb_wal_writes_failed_total",
+    "offset": 0,
+    "startOrEnd": null,
+    "timestamp": null,
+    "type": "vectorSelector"
+    });
+}

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -39,6 +39,55 @@ fn test_serialize() {
     });
 
     assert_json_ser_eq!(
+        "prometheus_tsdb_wal_writes_failed_total{label != \"nice\"}",
+
+        {
+            "matchers": [
+                {
+                    "name": "label",
+                    "type": "!=",
+                    "value": "nice"
+                }
+            ],
+            "name": "prometheus_tsdb_wal_writes_failed_total",
+            "offset": 0,
+            "type": "vectorSelector"
+        }
+    );
+
+    assert_json_ser_eq!(
+        "prometheus_tsdb_wal_writes_failed_total{label =~ \"nice\"}",
+
+    {
+        "matchers": [
+            {
+                "name": "label",
+                "type": "=~",
+                "value": "nice"
+            }
+        ],
+        "name": "prometheus_tsdb_wal_writes_failed_total",
+        "offset": 0,
+        "type": "vectorSelector"
+    });
+
+    assert_json_ser_eq!(
+        "prometheus_tsdb_wal_writes_failed_total{label !~ \"nice\"}",
+
+    {
+        "matchers": [
+            {
+                "name": "label",
+                "type": "!~",
+                "value": "nice"
+            }
+        ],
+        "name": "prometheus_tsdb_wal_writes_failed_total",
+        "offset": 0,
+        "type": "vectorSelector"
+    });
+
+    assert_json_ser_eq!(
         "prometheus_tsdb_wal_writes_failed_total offset 2s @ start()",
 
     {
@@ -274,6 +323,61 @@ fn test_serialize() {
                     "type": "binaryExpr"
                 },
                 "type": "parenExpr"
+            },
+            "type": "binaryExpr"
+        }
+    );
+
+    assert_json_ser_eq!("foo * on(branch) bar ",
+    {
+        "bool": false,
+        "lhs": {
+            "matchers": [],
+            "name": "foo",
+            "offset": 0,
+            "type": "vectorSelector"
+        },
+        "matching": {
+            "card": "one-to-one",
+            "include": [],
+            "labels": [
+            "branch"
+            ],
+            "on": true
+        },
+        "op": "*",
+        "rhs": {
+            "matchers": [],
+            "name": "bar",
+            "offset": 0,
+            "type": "vectorSelector"
+        },
+        "type": "binaryExpr"
+    });
+
+    assert_json_ser_eq!("foo * ignoring(branch) bar ",
+        {
+            "bool": false,
+            "lhs": {
+                "matchers": [],
+                "name": "foo",
+                "offset": 0,
+                "type": "vectorSelector"
+            },
+            "matching": {
+                "card": "one-to-one",
+                "include": [],
+                "labels": [
+                    "branch"
+                ],
+                "on": false
+            },
+            "op": "*",
+            "rhs": {
+                "matchers": [],
+                "name": "bar",
+                "offset": 0,
+                "type": "vectorSelector"
             },
             "type": "binaryExpr"
         }

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -32,17 +32,53 @@ fn test_serialize() {
         "prometheus_tsdb_wal_writes_failed_total",
 
     {
-    "matchers": [
-      {
-        "name": "__name__",
-        "type": "=",
-        "value": "prometheus_tsdb_wal_writes_failed_total"
-      }
-    ],
-    "name": "prometheus_tsdb_wal_writes_failed_total",
-    "offset": 0,
-    "startOrEnd": null,
-    "timestamp": null,
-    "type": "vectorSelector"
+        "matchers": [],
+        "name": "prometheus_tsdb_wal_writes_failed_total",
+        "offset": 0,
+        "type": "vectorSelector"
     });
+
+    assert_json_ser_eq!(
+        "prometheus_tsdb_wal_writes_failed_total offset 2s @ start()",
+
+    {
+        "matchers": [],
+        "name": "prometheus_tsdb_wal_writes_failed_total",
+        "offset": 2000,
+        "startOrEnd": "start",
+        "timestamp": null,
+        "type": "vectorSelector"
+    });
+
+    assert_json_ser_eq!(
+            "rate(prometheus_tsdb_wal_writes_failed_total{instance = \"localhost:9090\"}[1m])",
+
+    {
+        "args": [
+            {
+                "matchers": [
+                    {
+                        "name": "instance",
+                        "type": "=",
+                        "value": "localhost:9090"
+                    }
+                ],
+                "name": "prometheus_tsdb_wal_writes_failed_total",
+                "offset": 0,
+                "range": 60000,
+                "type": "matrixSelector"
+            }
+        ],
+        "func": {
+            "argTypes": [
+                "matrix"
+            ],
+            "name": "rate",
+            "returnType": "vector",
+            "variadic": 0
+        },
+        "type": "call"
+    }
+
+    );
 }


### PR DESCRIPTION
Fixes #93 

This patch attempts to add AST serialization to match output of prometheus 3.0 parse_query.