### PR TITLE
fix: unescape regex pattern 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ chrono = "0.4.38"
 lazy_static = "1.4.0"
 lrlex = "0.13.5"
 lrpar = "0.13.5"
+unescaper = "0.1"
 regex = "1"
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }

--- a/src/label/matcher.rs
+++ b/src/label/matcher.rs
@@ -115,8 +115,7 @@ impl Matcher {
     fn try_parse_re(original_re: &str) -> Result<Regex, String> {
         let re = format!(
             "^{}$",
-            unescaper::unescape(original_re)
-                .map_err(|e| format!("Invalid regex pattern, {}", e.to_string()))?
+            unescaper::unescape(original_re).map_err(|e| format!("Invalid regex pattern, {e}"))?
         );
         Regex::new(&re)
             .or_else(|_| Regex::new(&try_escape_for_repeat_re(&re)))
@@ -570,7 +569,7 @@ mod tests {
         assert!(!matcher.is_match("127.0.0.2"));
         // regex round trip
         let re = Matcher::try_parse_re(raw_input).unwrap();
-        let new_re = Regex::new(&re.as_str()).unwrap();
+        let new_re = Regex::new(re.as_str()).unwrap();
         assert_eq!(re.as_str(), new_re.as_str());
     }
 

--- a/src/label/matcher.rs
+++ b/src/label/matcher.rs
@@ -113,7 +113,11 @@ impl Matcher {
     ///
     /// Regex used in PromQL are fully anchored.
     fn try_parse_re(original_re: &str) -> Result<Regex, String> {
-        let re = format!("^{original_re}$");
+        let re = format!(
+            "^{}$",
+            unescaper::unescape(original_re)
+                .map_err(|e| format!("Invalid regex pattern, {}", e.to_string()))?
+        );
         Regex::new(&re)
             .or_else(|_| Regex::new(&try_escape_for_repeat_re(&re)))
             .map_err(|_| format!("illegal regex for {original_re}",))
@@ -545,6 +549,29 @@ mod tests {
         assert!(matcher.is_match("abc"));
         assert!(!matcher.is_match("xabc"));
         assert!(!matcher.is_match("abcx"));
+
+        let matcher = Matcher::new(
+            MatchOp::Re(Matcher::try_parse_re("127.0.0.1").unwrap()),
+            "code",
+            "127.0.0.1",
+        );
+        assert!(matcher.is_match("127.0.0.1"));
+        assert!(!matcher.is_match("x127.0.0.1"));
+        assert!(!matcher.is_match("127.0.0.2"));
+
+        let raw_input = r#"127\\.0\\.0\\.1"#;
+        let matcher = Matcher::new(
+            MatchOp::Re(Matcher::try_parse_re(raw_input).unwrap()),
+            "code",
+            raw_input,
+        );
+        assert!(matcher.is_match("127.0.0.1"));
+        assert!(!matcher.is_match("x127.0.0.1"));
+        assert!(!matcher.is_match("127.0.0.2"));
+        // regex round trip
+        let re = Matcher::try_parse_re(raw_input).unwrap();
+        let new_re = Regex::new(&re.as_str()).unwrap();
+        assert_eq!(re.as_str(), new_re.as_str());
     }
 
     #[test]


### PR DESCRIPTION
In fact the unescape should be handled on lex. But the current impl of lex only verifies if the escape sequence is valid, instead of really escaping them. 