### PR TITLE
fix: wrap regex with parentheses

### DIFF
--- a/src/label/matcher.rs
+++ b/src/label/matcher.rs
@@ -113,7 +113,7 @@ impl Matcher {
     ///
     /// Regex used in PromQL are fully anchored.
     fn try_parse_re(original_re: &str) -> Result<Regex, String> {
-        let re = format!("^{original_re}$");
+        let re = format!("^({original_re})$");
         Regex::new(&re)
             .or_else(|_| Regex::new(&try_escape_for_repeat_re(&re)))
             .map_err(|_| format!("illegal regex for {original_re}",))

--- a/src/label/matcher.rs
+++ b/src/label/matcher.rs
@@ -114,7 +114,7 @@ impl Matcher {
     /// Regex used in PromQL are fully anchored.
     fn try_parse_re(original_re: &str) -> Result<Regex, String> {
         let re = format!(
-            "^({})$",
+            "^(?:{})$",
             unescaper::unescape(original_re).map_err(|e| format!("Invalid regex pattern, {e}"))?
         );
         Regex::new(&re)

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -928,7 +928,7 @@ mod tests {
             }),
             (r#"foo:bar{a=~"bc{9}"}"#, {
                 let matchers = Matchers::one(Matcher::new(
-                    MatchOp::Re(Regex::new("^(bc{9})$").unwrap()),
+                    MatchOp::Re(Regex::new("^(?:bc{9})$").unwrap()),
                     "a",
                     "bc{9}",
                 ));
@@ -936,7 +936,7 @@ mod tests {
             }),
             (r#"foo:bar{a=~"bc{abc}"}"#, {
                 let matchers = Matchers::one(Matcher::new(
-                    MatchOp::Re(Regex::new("^(bc\\{abc})$").unwrap()),
+                    MatchOp::Re(Regex::new("^(?:bc\\{abc})$").unwrap()),
                     "a",
                     "bc{abc}",
                 ));
@@ -1340,7 +1340,11 @@ mod tests {
                 let name = String::from("nonexistent");
                 let matchers = Matchers::new(vec![
                     Matcher::new(MatchOp::Equal, "job", "myjob"),
-                    Matcher::new(MatchOp::Re(Regex::new("^(.*)$").unwrap()), "instance", ".*"),
+                    Matcher::new(
+                        MatchOp::Re(Regex::new("^(?:.*)$").unwrap()),
+                        "instance",
+                        ".*",
+                    ),
                 ]);
                 Expr::new_vector_selector(Some(name), matchers).and_then(|ex| {
                     Expr::new_call(get_function("absent").unwrap(), FunctionArgs::new_args(ex))
@@ -1375,7 +1379,11 @@ mod tests {
                     let name = String::from("nonexistent");
                     let matchers = Matchers::new(vec![
                         Matcher::new(MatchOp::Equal, "job", "myjob"),
-                        Matcher::new(MatchOp::Re(Regex::new("^(.*)$").unwrap()), "instance", ".*"),
+                        Matcher::new(
+                            MatchOp::Re(Regex::new("^(?:.*)$").unwrap()),
+                            "instance",
+                            ".*",
+                        ),
                     ]);
                     Expr::new_vector_selector(Some(name), matchers)
                         .and_then(|ex| Expr::new_matrix_selector(ex, duration::HOUR_DURATION))

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -928,7 +928,7 @@ mod tests {
             }),
             (r#"foo:bar{a=~"bc{9}"}"#, {
                 let matchers = Matchers::one(Matcher::new(
-                    MatchOp::Re(Regex::new("^bc{9}$").unwrap()),
+                    MatchOp::Re(Regex::new("^(bc{9})$").unwrap()),
                     "a",
                     "bc{9}",
                 ));
@@ -936,7 +936,7 @@ mod tests {
             }),
             (r#"foo:bar{a=~"bc{abc}"}"#, {
                 let matchers = Matchers::one(Matcher::new(
-                    MatchOp::Re(Regex::new("^bc\\{abc}$").unwrap()),
+                    MatchOp::Re(Regex::new("^(bc\\{abc})$").unwrap()),
                     "a",
                     "bc{abc}",
                 ));
@@ -1340,7 +1340,7 @@ mod tests {
                 let name = String::from("nonexistent");
                 let matchers = Matchers::new(vec![
                     Matcher::new(MatchOp::Equal, "job", "myjob"),
-                    Matcher::new(MatchOp::Re(Regex::new("^.*$").unwrap()), "instance", ".*"),
+                    Matcher::new(MatchOp::Re(Regex::new("^(.*)$").unwrap()), "instance", ".*"),
                 ]);
                 Expr::new_vector_selector(Some(name), matchers).and_then(|ex| {
                     Expr::new_call(get_function("absent").unwrap(), FunctionArgs::new_args(ex))
@@ -1375,7 +1375,7 @@ mod tests {
                     let name = String::from("nonexistent");
                     let matchers = Matchers::new(vec![
                         Matcher::new(MatchOp::Equal, "job", "myjob"),
-                        Matcher::new(MatchOp::Re(Regex::new("^.*$").unwrap()), "instance", ".*"),
+                        Matcher::new(MatchOp::Re(Regex::new("^(.*)$").unwrap()), "instance", ".*"),
                     ]);
                     Expr::new_vector_selector(Some(name), matchers)
                         .and_then(|ex| Expr::new_matrix_selector(ex, duration::HOUR_DURATION))


### PR DESCRIPTION
In case `a|b|c` will become `^a|b|c$` instead of `^(a|b|c)$`