### PR TITLE
feat: fill*() binop modifiers

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -17,10 +17,10 @@ use lrlex::{ct_token_map, DefaultLexerTypes};
 use lrpar::CTParserBuilder;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let ctp = CTParserBuilder::<DefaultLexerTypes<u8>>::new()
+    let ctp = CTParserBuilder::<DefaultLexerTypes<u16>>::new()
         .yacckind(YaccKind::Grmtools)
         .recoverer(lrpar::RecoveryKind::None)
         .grammar_in_src_dir("parser/promql.y")?
         .build()?;
-    ct_token_map::<u8>("token_map", ctp.token_map(), None)
+    ct_token_map::<u16>("token_map", ctp.token_map(), None)
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -100,8 +100,38 @@ impl VectorMatchCardinality {
     }
 }
 
+/// VectorMatchFillValues contains the fill values to use for Vector matching
+/// when one side does not find a match on the other side.
+/// When a fill value is nil, no fill is applied for that side, and there
+/// is no output for the match group if there is no match.
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "ser", derive(serde::Serialize))]
+pub struct VectorMatchFillValues {
+    pub rhs: Option<f64>,
+    pub lhs: Option<f64>,
+}
+
+impl VectorMatchFillValues {
+    pub fn new(lhs: f64, rhs: f64) -> Self {
+        Self {
+            rhs: Some(rhs),
+            lhs: Some(lhs),
+        }
+    }
+
+    pub fn with_rhs(mut self, rhs: f64) -> Self {
+        self.rhs = Some(rhs);
+        self
+    }
+
+    pub fn with_lhs(mut self, lhs: f64) -> Self {
+        self.lhs = Some(lhs);
+        self
+    }
+}
+
 /// Binary Expr Modifier
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct BinModifier {
     /// The matching behavior for the operation if both operands are Vectors.
     /// If they are not this field is None.
@@ -112,6 +142,9 @@ pub struct BinModifier {
     pub matching: Option<LabelModifier>,
     /// If a comparison operator, return 0/1 rather than filtering.
     pub return_bool: bool,
+    /// Fill-in values to use when a series from one side does not find a match
+    /// on the other side.
+    pub fill_values: VectorMatchFillValues,
 }
 
 impl fmt::Display for BinModifier {
@@ -132,6 +165,21 @@ impl fmt::Display for BinModifier {
             _ => (),
         }
 
+        if self.fill_values.rhs.is_some() || self.fill_values.lhs.is_some() {
+            if self.fill_values.rhs == self.fill_values.lhs {
+                let fill_value = self.fill_values.rhs.unwrap();
+                write!(s, "fill ({fill_value}) ")?;
+            } else {
+                if let Some(fill_value) = self.fill_values.lhs {
+                    write!(s, "fill_left ({fill_value}) ")?;
+                }
+
+                if let Some(fill_value) = self.fill_values.rhs {
+                    write!(s, "fill_right ({fill_value}) ")?;
+                }
+            }
+        }
+
         if s.trim().is_empty() {
             write!(f, "")
         } else {
@@ -146,6 +194,7 @@ impl Default for BinModifier {
             card: VectorMatchCardinality::OneToOne,
             matching: None,
             return_bool: false,
+            fill_values: VectorMatchFillValues::default(),
         }
     }
 }
@@ -163,6 +212,11 @@ impl BinModifier {
 
     pub fn with_return_bool(mut self, return_bool: bool) -> Self {
         self.return_bool = return_bool;
+        self
+    }
+
+    pub fn with_fill_values(mut self, fill_values: VectorMatchFillValues) -> Self {
+        self.fill_values = fill_values;
         self
     }
 
@@ -255,6 +309,7 @@ where
                         "include": [],
                         "labels": labels,
                         "on": true,
+                        "fillValues": t.fill_values,
                     });
                     map.serialize_value(&value)?;
                 }
@@ -264,6 +319,7 @@ where
                         "include": [],
                         "labels": labels,
                         "on": false,
+                        "fillValues": t.fill_values,
                     });
                     map.serialize_value(&value)?;
                 }
@@ -274,6 +330,7 @@ where
                 "include": [],
                 "labels": [],
                 "on": false,
+                "fillValues": t.fill_values,
             });
             map.serialize_entry("matching", &value)?;
         }
@@ -322,7 +379,7 @@ where
     map.end()
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Offset {
     Pos(Duration),
     Neg(Duration),
@@ -359,7 +416,7 @@ impl fmt::Display for Offset {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum AtModifier {
     Start,
     End,
@@ -487,7 +544,7 @@ impl fmt::Display for EvalStmt {
 /// ```
 ///
 /// parameter is only required for `count_values`, `quantile`, `topk` and `bottomk`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct AggregateExpr {
     /// The used aggregation operation.
@@ -544,7 +601,7 @@ impl Prettier for AggregateExpr {
 }
 
 /// UnaryExpr will negate the expr
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct UnaryExpr {
     pub expr: Box<Expr>,
 }
@@ -587,7 +644,7 @@ impl serde::Serialize for UnaryExpr {
 /// <vector expr> <bin-op> on(<label list>) group_left(<label list>) <vector expr>
 /// <vector expr> <bin-op> on(<label list>) group_right(<label list>) <vector expr>
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct BinaryExpr {
     /// The operation of the expression.
@@ -658,7 +715,7 @@ impl Prettier for BinaryExpr {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct ParenExpr {
     pub expr: Box<Expr>,
@@ -685,7 +742,7 @@ impl Prettier for ParenExpr {
 /// ```norust
 /// <instant_query> '[' <range> ':' [<resolution>] ']' [ @ <float_literal> ] [ offset <duration> ]
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct SubqueryExpr {
     pub expr: Box<Expr>,
@@ -805,7 +862,7 @@ impl Prettier for NumberLiteral {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct StringLiteral {
     pub val: String,
@@ -823,7 +880,7 @@ impl Prettier for StringLiteral {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct VectorSelector {
     pub name: Option<String>,
@@ -928,7 +985,7 @@ impl Prettier for VectorSelector {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct MatrixSelector {
     #[cfg_attr(feature = "ser", serde(flatten))]
@@ -1010,7 +1067,7 @@ impl Prettier for MatrixSelector {
 ///  - sinh()
 ///  - tan()
 ///  - tanh()
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct Call {
     pub func: Function,
@@ -1061,7 +1118,7 @@ impl PartialEq for Extension {
 
 impl Eq for Extension {}
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 #[cfg_attr(feature = "ser", serde(tag = "type", rename_all = "camelCase"))]
 pub enum Expr {
@@ -1988,6 +2045,17 @@ mod tests {
             ("a - on(b) group_left c", "a - on (b) group_left () c"),
             ("a - ignoring(b) c", "a - ignoring (b) c"),
             ("a - ignoring() c", "a - c"),
+            ("a + fill(-23) b", "a + fill (-23) b"),
+            ("a + fill_left(-23) b", "a + fill_left (-23) b"),
+            ("a + fill_right(42) b", "a + fill_right (42) b"),
+            (
+                "a + fill_left(-23) fill_right(42) b",
+                "a + fill_left (-23) fill_right (42) b",
+            ),
+            (
+                "a + on(b) group_left fill(-23) c",
+                "a + on (b) group_left () fill (-23) c",
+            ),
             ("up > bool 0", "up > bool 0"),
             ("a offset 1m", "a offset 1m"),
             ("a offset -7m", "a offset -7m"),

--- a/src/parser/function.rs
+++ b/src/parser/function.rs
@@ -22,7 +22,7 @@ use crate::parser::{Expr, Prettier};
 use crate::util::join_vector;
 
 /// called by func in Call
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "ser", derive(serde::Serialize))]
 pub struct FunctionArgs {
     pub args: Vec<Box<Expr>>,

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -429,11 +429,7 @@ impl Lexer {
                     }
                     if !found_lparen {
                         // Not followed by (, treat as metric identifier
-                        if s.contains(':') {
-                            return State::Lexeme(T_METRIC_IDENTIFIER);
-                        } else {
-                            return State::Lexeme(T_IDENTIFIER);
-                        }
+                        return State::Lexeme(T_IDENTIFIER);
                     }
                 }
                 State::Lexeme(token_id)

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -408,8 +408,36 @@ impl Lexer {
         }
 
         let s = self.lexeme_string();
-        match get_keyword_token(&s.to_lowercase()) {
-            Some(token_id) => State::Lexeme(token_id),
+        let s_lower = s.to_lowercase();
+        match get_keyword_token(&s_lower) {
+            Some(token_id) => {
+                // fill, fill_left, fill_right can be used as metric identifiers
+                // if not followed by a left parenthesis
+                if token_id == T_FILL || token_id == T_FILL_LEFT || token_id == T_FILL_RIGHT {
+                    // Look ahead to see if next non-whitespace char is '('
+                    let mut idx = self.ctx.idx;
+                    let mut found_lparen = false;
+                    while let Some(&ch) = self.ctx.chars.get(idx) {
+                        if ch.is_ascii_whitespace() {
+                            idx += 1;
+                        } else if ch == '(' {
+                            found_lparen = true;
+                            break;
+                        } else {
+                            break;
+                        }
+                    }
+                    if !found_lparen {
+                        // Not followed by (, treat as metric identifier
+                        if s.contains(':') {
+                            return State::Lexeme(T_METRIC_IDENTIFIER);
+                        } else {
+                            return State::Lexeme(T_IDENTIFIER);
+                        }
+                    }
+                }
+                State::Lexeme(token_id)
+            }
             None if s.contains(':') => State::Lexeme(T_METRIC_IDENTIFIER),
             _ => State::Lexeme(T_IDENTIFIER),
         }
@@ -915,20 +943,6 @@ mod tests {
     }
 
     #[test]
-    fn test_aggregators() {
-        let cases = vec![
-            ("sum", vec![(T_SUM, 0, 3)], None),
-            ("AVG", vec![(T_AVG, 0, 3)], None),
-            ("Max", vec![(T_MAX, 0, 3)], None),
-            ("min", vec![(T_MIN, 0, 3)], None),
-            ("count", vec![(T_COUNT, 0, 5)], None),
-            ("stdvar", vec![(T_STDVAR, 0, 6)], None),
-            ("stddev", vec![(T_STDDEV, 0, 6)], None),
-        ];
-        assert_matches(cases);
-    }
-
-    #[test]
     fn test_keywords() {
         let cases = vec![
             ("offset", vec![(T_OFFSET, 0, 6)], None),
@@ -940,6 +954,72 @@ mod tests {
             ("group_right", vec![(T_GROUP_RIGHT, 0, 11)], None),
             ("bool", vec![(T_BOOL, 0, 4)], None),
             ("atan2", vec![(T_ATAN2, 0, 5)], None),
+            // fill as metric identifier (not followed by ()
+            ("fill", vec![(T_IDENTIFIER, 0, 4)], None),
+            ("fill_left", vec![(T_IDENTIFIER, 0, 9)], None),
+            ("fill_right", vec![(T_IDENTIFIER, 0, 10)], None),
+            // fill as modifier (followed by ()
+            (
+                "fill(1)",
+                vec![
+                    (T_FILL, 0, 4),
+                    (T_LEFT_PAREN, 4, 1),
+                    (T_NUMBER, 5, 1),
+                    (T_RIGHT_PAREN, 6, 1),
+                ],
+                None,
+            ),
+            (
+                "fill_left(1)",
+                vec![
+                    (T_FILL_LEFT, 0, 9),
+                    (T_LEFT_PAREN, 9, 1),
+                    (T_NUMBER, 10, 1),
+                    (T_RIGHT_PAREN, 11, 1),
+                ],
+                None,
+            ),
+            (
+                "fill_right(2)",
+                vec![
+                    (T_FILL_RIGHT, 0, 10),
+                    (T_LEFT_PAREN, 10, 1),
+                    (T_NUMBER, 11, 1),
+                    (T_RIGHT_PAREN, 12, 1),
+                ],
+                None,
+            ),
+            // fill with whitespace before (
+            (
+                "fill (1)",
+                vec![
+                    (T_FILL, 0, 4),
+                    (T_LEFT_PAREN, 5, 1),
+                    (T_NUMBER, 6, 1),
+                    (T_RIGHT_PAREN, 7, 1),
+                ],
+                None,
+            ),
+            (
+                "fill_left (1)",
+                vec![
+                    (T_FILL_LEFT, 0, 9),
+                    (T_LEFT_PAREN, 10, 1),
+                    (T_NUMBER, 11, 1),
+                    (T_RIGHT_PAREN, 12, 1),
+                ],
+                None,
+            ),
+            (
+                "fill_right (2)",
+                vec![
+                    (T_FILL_RIGHT, 0, 10),
+                    (T_LEFT_PAREN, 11, 1),
+                    (T_NUMBER, 12, 1),
+                    (T_RIGHT_PAREN, 13, 1),
+                ],
+                None,
+            ),
         ];
         assert_matches(cases);
     }

--- a/src/parser/lex.rs
+++ b/src/parser/lex.rs
@@ -943,6 +943,20 @@ mod tests {
     }
 
     #[test]
+    fn test_aggregators() {
+        let cases = vec![
+            ("sum", vec![(T_SUM, 0, 3)], None),
+            ("AVG", vec![(T_AVG, 0, 3)], None),
+            ("Max", vec![(T_MAX, 0, 3)], None),
+            ("min", vec![(T_MIN, 0, 3)], None),
+            ("count", vec![(T_COUNT, 0, 5)], None),
+            ("stdvar", vec![(T_STDVAR, 0, 6)], None),
+            ("stddev", vec![(T_STDDEV, 0, 6)], None),
+        ];
+        assert_matches(cases);
+    }
+
+    #[test]
     fn test_keywords() {
         let cases = vec![
             ("offset", vec![(T_OFFSET, 0, 6)], None),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -31,7 +31,7 @@ pub mod value;
 pub use ast::{
     AggregateExpr, AtModifier, BinModifier, BinaryExpr, Call, EvalStmt, Expr, Extension,
     LabelModifier, MatrixSelector, NumberLiteral, Offset, ParenExpr, StringLiteral, SubqueryExpr,
-    UnaryExpr, VectorMatchCardinality, VectorSelector,
+    UnaryExpr, VectorMatchCardinality, VectorMatchFillValues, VectorSelector,
 };
 pub use function::{Function, FunctionArgs};
 pub use lex::lexer;

--- a/src/parser/promql.y
+++ b/src/parser/promql.y
@@ -265,27 +265,28 @@ group_modifiers -> Result<Option<BinModifier>, String>:
 ;
 
 fill_modifiers -> Result<Option<BinModifier>, String>:
-                group_modifiers { $1 }
-         |      group_modifiers FILL fill_value
-                {
-                         Ok(update_optional_fill($1?, VectorMatchFillValues::new($3, $3)))
-                }
-         |      group_modifiers FILL_LEFT fill_value
-                {
-                        Ok(update_optional_fill($1?, VectorMatchFillValues::default().with_lhs($3)))
-                }
-         |      group_modifiers FILL_RIGHT fill_value
-                {
-                        Ok(update_optional_fill($1?, VectorMatchFillValues::default().with_rhs($3)))
-                }
-         |      group_modifiers FILL_LEFT fill_value FILL_RIGHT fill_value
-                {
-                        Ok(update_optional_fill($1?, VectorMatchFillValues::new($3, $5)))
-                }
-         |      group_modifiers FILL_RIGHT fill_value FILL_LEFT fill_value
-                {
-                        Ok(update_optional_fill($1?, VectorMatchFillValues::new($5, $3)))
-                }
+                 group_modifiers { $1 }
+        |        group_modifiers FILL fill_value
+                 {
+                         let fill = $3?;
+                         Ok(update_optional_fill($1?, VectorMatchFillValues::new(fill, fill)))
+                 }
+        |        group_modifiers FILL_LEFT fill_value
+                 {
+                         Ok(update_optional_fill($1?, VectorMatchFillValues::default().with_lhs($3?)))
+                 }
+        |        group_modifiers FILL_RIGHT fill_value
+                 {
+                         Ok(update_optional_fill($1?, VectorMatchFillValues::default().with_rhs($3?)))
+                 }
+        |        group_modifiers FILL_LEFT fill_value FILL_RIGHT fill_value
+                 {
+                         Ok(update_optional_fill($1?, VectorMatchFillValues::new($3?, $5?)))
+                 }
+        |        group_modifiers FILL_RIGHT fill_value FILL_LEFT fill_value
+                 {
+                         Ok(update_optional_fill($1?, VectorMatchFillValues::new($5?, $3?)))
+                 }
 ;
 
 grouping_labels -> Result<Labels, String>:
@@ -316,14 +317,30 @@ grouping_label -> Result<Token, String>:
                 }
 ;
 
-fill_value -> f64:
-                LEFT_PAREN number_duration_literal RIGHT_PAREN
+fill_value -> Result<f64, String>:
+                LEFT_PAREN NUMBER RIGHT_PAREN
                 {
-                        $2
+                        if let Ok(tok) = $2 {
+                            parse_str_radix($lexer.span_str(tok.span()))
+                        } else {
+                            Err("Number expected for fill value".to_string())
+                        }
                 }
-        |       LEFT_PAREN SUB number_duration_literal RIGHT_PAREN
+        |       LEFT_PAREN ADD NUMBER RIGHT_PAREN
                 {
-                        -$3
+                        if let Ok(tok) = $3 {
+                            parse_str_radix($lexer.span_str(tok.span()))
+                        } else {
+                            Err("Number expected for fill value".to_string())
+                        }
+                }
+        |       LEFT_PAREN SUB NUMBER RIGHT_PAREN
+                {
+                        if let Ok(tok) = $3 {
+                            parse_str_radix($lexer.span_str(tok.span())).map(|v| -v)
+                        } else {
+                            Err("Number expected for fill value".to_string())
+                        }
                 }
 ;
 
@@ -638,21 +655,6 @@ number_literal -> Result<Expr, String>:
                 {
                         let duration = parse_duration($lexer.span_str($span))?;
                         Ok(Expr::from(duration.as_secs_f64()))
-                }
-;
-
-/*
- * Number or duration literal for fill values.
- */
-number_duration_literal -> f64:
-                NUMBER
-                {
-                        parse_str_radix($lexer.span_str($span)).unwrap()
-                }
-        |       DURATION
-                {
-                        let duration = parse_duration($lexer.span_str($span)).unwrap();
-                        duration.as_secs_f64()
                 }
 ;
 

--- a/src/parser/promql.y
+++ b/src/parser/promql.y
@@ -90,6 +90,9 @@ BOOL
 BY
 GROUP_LEFT
 GROUP_RIGHT
+FILL
+FILL_LEFT
+FILL_RIGHT
 IGNORING
 OFFSET
 SMOOTHED
@@ -119,6 +122,8 @@ START_METRIC_SELECTOR
 %expect-unused 'STEP' 'STARTSYMBOLS_START'
 %expect-unused 'START_METRIC' 'START_SERIES_DESCRIPTION' 'START_EXPRESSION' 'START_METRIC_SELECTOR' 'STARTSYMBOLS_END'
 %expect-unused 'SMOOTHED' 'ANCHORED'
+
+%expect 5
 
 %start start
 
@@ -213,7 +218,7 @@ binary_expr -> Result<Expr, String>:
 // Using left recursion for the modifier rules, helps to keep the parser stack small and
 // reduces allocations
 bin_modifier -> Result<Option<BinModifier>, String>:
-                group_modifiers { $1 }
+                fill_modifiers { $1 }
 ;
 
 bool_modifier -> Result<Option<BinModifier>, String>:
@@ -259,6 +264,30 @@ group_modifiers -> Result<Option<BinModifier>, String>:
         |       GROUP_RIGHT grouping_labels { Err("unexpected <group_right>".into()) }
 ;
 
+fill_modifiers -> Result<Option<BinModifier>, String>:
+                group_modifiers { $1 }
+         |      group_modifiers FILL fill_value
+                {
+                         Ok(update_optional_fill($1?, VectorMatchFillValues::new($3, $3)))
+                }
+         |      group_modifiers FILL_LEFT fill_value
+                {
+                        Ok(update_optional_fill($1?, VectorMatchFillValues::default().with_lhs($3)))
+                }
+         |      group_modifiers FILL_RIGHT fill_value
+                {
+                        Ok(update_optional_fill($1?, VectorMatchFillValues::default().with_rhs($3)))
+                }
+         |      group_modifiers FILL_LEFT fill_value FILL_RIGHT fill_value
+                {
+                        Ok(update_optional_fill($1?, VectorMatchFillValues::new($3, $5)))
+                }
+         |      group_modifiers FILL_RIGHT fill_value FILL_LEFT fill_value
+                {
+                        Ok(update_optional_fill($1?, VectorMatchFillValues::new($5, $3)))
+                }
+;
+
 grouping_labels -> Result<Labels, String>:
                 LEFT_PAREN grouping_label_list RIGHT_PAREN { $2 }
         |       LEFT_PAREN grouping_label_list COMMA RIGHT_PAREN { $2 }
@@ -284,6 +313,17 @@ grouping_label -> Result<Token, String>:
         |       STRING {
                         let name = unquote_string($lexer.span_str($span))?;
                         Ok(Token::new(T_IDENTIFIER, name))
+                }
+;
+
+fill_value -> f64:
+                LEFT_PAREN number_duration_literal RIGHT_PAREN
+                {
+                        $2
+                }
+        |       LEFT_PAREN SUB number_duration_literal RIGHT_PAREN
+                {
+                        -$3
                 }
 ;
 
@@ -498,6 +538,9 @@ metric_identifier -> Result<Token, String>:
         |       BY { lexeme_to_token($lexer, $1) }
         |       COUNT { lexeme_to_token($lexer, $1) }
         |       COUNT_VALUES { lexeme_to_token($lexer, $1) }
+        |       FILL { lexeme_to_token($lexer, $1) }
+        |       FILL_LEFT { lexeme_to_token($lexer, $1) }
+        |       FILL_RIGHT { lexeme_to_token($lexer, $1) }
         |       GROUP { lexeme_to_token($lexer, $1) }
         |       IDENTIFIER { lexeme_to_token($lexer, $1) }
         |       LAND { lexeme_to_token($lexer, $1) }
@@ -549,6 +592,9 @@ maybe_label -> Result<Token, String>:
         |       BY { lexeme_to_token($lexer, $1) }
         |       COUNT { lexeme_to_token($lexer, $1) }
         |       COUNT_VALUES { lexeme_to_token($lexer, $1) }
+        |       FILL { lexeme_to_token($lexer, $1) }
+        |       FILL_LEFT { lexeme_to_token($lexer, $1) }
+        |       FILL_RIGHT { lexeme_to_token($lexer, $1) }
         |       GROUP { lexeme_to_token($lexer, $1) }
         |       GROUP_LEFT { lexeme_to_token($lexer, $1) }
         |       GROUP_RIGHT { lexeme_to_token($lexer, $1) }
@@ -595,6 +641,21 @@ number_literal -> Result<Expr, String>:
                 }
 ;
 
+/*
+ * Number or duration literal for fill values.
+ */
+number_duration_literal -> f64:
+                NUMBER
+                {
+                        parse_str_radix($lexer.span_str($span)).unwrap()
+                }
+        |       DURATION
+                {
+                        let duration = parse_duration($lexer.span_str($span)).unwrap();
+                        duration.as_secs_f64()
+                }
+;
+
 string_literal -> Result<Expr, String>:
                 STRING { Ok(Expr::from(unquote_string(&span_to_string($lexer, $span))?)) }
 ;
@@ -627,7 +688,7 @@ maybe_duration -> Result<Option<Duration>, String>:
 
 use std::time::Duration;
 use crate::label::{Labels, Matcher, Matchers};
-use crate::parser::{AtModifier, BinModifier, Expr, FunctionArgs, LabelModifier, Offset, VectorMatchCardinality};
+use crate::parser::{AtModifier, BinModifier, Expr, FunctionArgs, LabelModifier, Offset, VectorMatchCardinality, VectorMatchFillValues};
 use crate::parser::ast::check_ast;
 use crate::parser::function::get_function;
 use crate::parser::lex::is_label;
@@ -649,4 +710,12 @@ fn update_optional_card(
 ) -> Option<BinModifier> {
     let modifier = modifier.unwrap_or_default();
     Some(modifier.with_card(card))
+}
+
+fn update_optional_fill(
+    modifier: Option<BinModifier>,
+    fill: VectorMatchFillValues,
+) -> Option<BinModifier> {
+    let modifier = modifier.unwrap_or_default();
+    Some(modifier.with_fill_values(fill))
 }

--- a/src/parser/token.rs
+++ b/src/parser/token.rs
@@ -19,7 +19,7 @@ use std::fmt;
 lrlex::lrlex_mod!("token_map");
 pub use token_map::*;
 
-pub type TokenId = u8;
+pub type TokenId = u16;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct TokenType(TokenId);
@@ -70,6 +70,9 @@ lazy_static! {
             ("bool", T_BOOL),
             ("smoothed", T_SMOOTHED),
             ("anchored", T_ANCHORED),
+            ("fill", T_FILL),
+            ("fill_left", T_FILL_LEFT),
+            ("fill_right", T_FILL_RIGHT),
 
             // Preprocessors.
             ("start", T_START),
@@ -163,6 +166,9 @@ pub(crate) fn token_display(id: TokenId) -> &'static str {
         T_ANCHORED => "anchored",
         T_ON => "on",
         T_WITHOUT => "without",
+        T_FILL => "fill",
+        T_FILL_LEFT => "fill_left",
+        T_FILL_RIGHT => "fill_right",
         T_KEYWORDS_END => "keywords_end",
 
         // Preprocessors.
@@ -321,6 +327,9 @@ mod tests {
         assert_eq!(token_display(T_OFFSET), "offset");
         assert_eq!(token_display(T_SMOOTHED), "smoothed");
         assert_eq!(token_display(T_ANCHORED), "anchored");
+        assert_eq!(token_display(T_FILL), "fill");
+        assert_eq!(token_display(T_FILL_LEFT), "fill_left");
+        assert_eq!(token_display(T_FILL_RIGHT), "fill_right");
         assert_eq!(token_display(T_ON), "on");
         assert_eq!(token_display(T_WITHOUT), "without");
         assert_eq!(token_display(T_KEYWORDS_END), "keywords_end");
@@ -331,13 +340,13 @@ mod tests {
         assert_eq!(token_display(T_PREPROCESSOR_END), "preprocessors_end");
 
         // if new token added in promql.y, this has to be updated
-        for i in 77..=82 {
+        for i in 80..=85 {
             assert_eq!(token_display(i), "not used");
         }
 
         // All tokens are now tested individually above
 
-        for i in 83..=255 {
+        for i in 86..=u16::MAX {
             assert_eq!(token_display(i), "unknown token");
         }
     }
@@ -379,6 +388,12 @@ mod tests {
         assert!(matches!(get_keyword_token("bool"), Some(T_BOOL)));
         assert!(matches!(get_keyword_token("start"), Some(T_START)));
         assert!(matches!(get_keyword_token("end"), Some(T_END)));
+        assert!(matches!(get_keyword_token("fill"), Some(T_FILL)));
+        assert!(matches!(get_keyword_token("fill_left"), Some(T_FILL_LEFT)));
+        assert!(matches!(
+            get_keyword_token("fill_right"),
+            Some(T_FILL_RIGHT)
+        ));
         assert!(matches!(get_keyword_token("inf"), Some(T_NUMBER)));
         assert!(matches!(get_keyword_token("nan"), Some(T_NUMBER)));
 

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -245,7 +245,11 @@ fn test_serialize() {
                                 "card": "many-to-many",
                                 "include": [],
                                 "labels": [],
-                                "on": false
+                                "on": false,
+                                "fillValues": {
+                                    "lhs": null,
+                                    "rhs": null
+                                }
                             },
                             "op": "or",
                             "rhs": {
@@ -370,7 +374,11 @@ fn test_serialize() {
             "labels": [
             "branch"
             ],
-            "on": true
+            "on": true,
+            "fillValues": {
+                "lhs": null,
+                "rhs": null
+            }
         },
         "op": "*",
         "rhs": {
@@ -401,7 +409,45 @@ fn test_serialize() {
                 "labels": [
                     "branch"
                 ],
-                "on": false
+                "on": false,
+                "fillValues": {
+                    "lhs": null,
+                    "rhs": null
+                }
+            },
+            "op": "*",
+            "rhs": {
+                "matchers": [],
+                "name": "bar",
+                "offset": 0,
+                "type": "vectorSelector",
+                "startOrEnd": null,
+                "timestamp": null
+            },
+            "type": "binaryExpr"
+        }
+    );
+
+    assert_json_ser_eq!("foo * fill (42) bar",
+        {
+            "bool": false,
+            "lhs": {
+                "matchers": [],
+                "name": "foo",
+                "offset": 0,
+                "type": "vectorSelector",
+                "startOrEnd": null,
+                "timestamp": null
+            },
+            "matching": {
+                "card": "one-to-one",
+                "include": [],
+                "labels": [],
+                "on": false,
+                "fillValues": {
+                    "lhs": 42.0,
+                    "rhs": 42.0
+                }
             },
             "op": "*",
             "rhs": {


### PR DESCRIPTION
Add our parser implementation for Prometheus 3.10 fill modifiers https://github.com/prometheus/prometheus/pull/17644

pending tasks:

- [x] figure out if it's really necessary to expand tokenId to u16, and the conflicts currently suppressed by `%expect 5`
- [x] support identifier called `fill`, `fill_left` and `fill_right`
