### PR TITLE
feat: add mutable visitor trait for traversal of AST

### DIFF
--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1052,7 +1052,7 @@ pub trait ExtensionExpr: std::fmt::Debug + Send + Sync {
 
     fn children(&self) -> &[Expr];
 
-    fn children_mut(&mut self) -> &mut [Expr];
+    fn with_new_children(&self, children: Vec<Expr>) -> Arc<dyn ExtensionExpr>;
 }
 
 impl PartialEq for Extension {

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1051,6 +1051,8 @@ pub trait ExtensionExpr: std::fmt::Debug + Send + Sync {
     fn value_type(&self) -> ValueType;
 
     fn children(&self) -> &[Expr];
+
+    fn children_mut(&mut self) -> &mut [Expr];
 }
 
 impl PartialEq for Extension {

--- a/src/util/visitor.rs
+++ b/src/util/visitor.rs
@@ -507,6 +507,7 @@ mod tests {
             if let Expr::VectorSelector(vs) = &children[0] {
                 assert_eq!(vs.matchers.matchers.len(), 1);
                 assert_eq!(vs.matchers.matchers[0].name, "env");
+                assert_eq!(vs.matchers.matchers[0].value, "prod");
             } else {
                 panic!("expected first child to be a VectorSelector");
             }

--- a/src/util/visitor.rs
+++ b/src/util/visitor.rs
@@ -124,13 +124,15 @@ pub fn walk_expr_mut<V: ExprVisitorMut>(
         Expr::Subquery(SubqueryExpr { expr, .. }) => walk_expr_mut(visitor, expr)?,
         Expr::Extension(Extension { expr }) => {
             let mut children = expr.children().to_vec();
+            let mut recurse = true;
             for child in &mut children {
                 if !walk_expr_mut(visitor, child)? {
-                    return Ok(false);
+                    recurse = false;
+                    break;
                 }
             }
             *expr = expr.with_new_children(children);
-            true
+            recurse
         }
         Expr::Call(call) => {
             for func_argument_expr in &mut call.args.args {
@@ -308,6 +310,7 @@ mod tests {
     struct LabelInjectorVisitor {
         label_name: String,
         label_value: String,
+        inject_once: bool,
     }
 
     impl ExprVisitorMut for LabelInjectorVisitor {
@@ -323,6 +326,10 @@ mod tests {
                         name: self.label_name.clone(),
                         value: self.label_value.clone(),
                     });
+
+                if self.inject_once {
+                    return Ok(false);
+                }
             }
             Ok(true)
         }
@@ -336,6 +343,7 @@ mod tests {
         let mut visitor = LabelInjectorVisitor {
             label_name: "namespace".to_string(),
             label_value: "injected".to_string(),
+            inject_once: false,
         };
 
         assert!(walk_expr_mut(&mut visitor, &mut ast).unwrap());
@@ -358,6 +366,7 @@ mod tests {
         let mut visitor = LabelInjectorVisitor {
             label_name: "env".to_string(),
             label_value: "prod".to_string(),
+            inject_once: false,
         };
 
         assert!(walk_expr_mut(&mut visitor, &mut ast).unwrap());
@@ -383,6 +392,7 @@ mod tests {
         let mut visitor = LabelInjectorVisitor {
             label_name: "env".to_string(),
             label_value: "prod".to_string(),
+            inject_once: false,
         };
 
         assert!(walk_expr_mut(&mut visitor, &mut ast).unwrap());
@@ -447,6 +457,7 @@ mod tests {
         let mut visitor = LabelInjectorVisitor {
             label_name: "env".to_string(),
             label_value: "prod".to_string(),
+            inject_once: false,
         };
         assert!(walk_expr_mut(&mut visitor, &mut ast).unwrap());
 
@@ -460,6 +471,51 @@ mod tests {
                 assert_eq!(vs.matchers.matchers[0].value, "prod");
             } else {
                 panic!("expected inner expression to be a VectorSelector");
+            }
+        } else {
+            panic!("expected Extension expression");
+        }
+    }
+
+    #[test]
+    fn test_extension_partial_mutation_on_short_circuit() {
+        let child1 = parser::parse("metric_a{}").unwrap();
+        let child2 = parser::parse("metric_b{}").unwrap();
+
+        let dummy_ext = DummyExtension {
+            children: vec![child1, child2],
+        };
+
+        let mut ast = Expr::Extension(parser::Extension {
+            expr: std::sync::Arc::new(dummy_ext),
+        });
+
+        let mut visitor = LabelInjectorVisitor {
+            label_name: "env".to_string(),
+            label_value: "prod".to_string(),
+            inject_once: true,
+        };
+
+        // The walker returns Ok(false) because it short-circuits after mutating the first child.
+        assert_eq!(walk_expr_mut(&mut visitor, &mut ast), Ok(false));
+
+        if let Expr::Extension(ext) = &ast {
+            let children = ext.expr.children();
+            assert_eq!(children.len(), 2);
+
+            // The first child should have been mutated.
+            if let Expr::VectorSelector(vs) = &children[0] {
+                assert_eq!(vs.matchers.matchers.len(), 1);
+                assert_eq!(vs.matchers.matchers[0].name, "env");
+            } else {
+                panic!("expected first child to be a VectorSelector");
+            }
+
+            // The second child remains untouched.
+            if let Expr::VectorSelector(vs) = &children[1] {
+                assert!(vs.matchers.matchers.is_empty());
+            } else {
+                panic!("expected second child to be a VectorSelector");
             }
         } else {
             panic!("expected Extension expression");

--- a/src/util/visitor.rs
+++ b/src/util/visitor.rs
@@ -15,7 +15,6 @@
 use crate::parser::{
     AggregateExpr, BinaryExpr, Expr, Extension, ParenExpr, SubqueryExpr, UnaryExpr,
 };
-use std::sync::Arc;
 
 /// Trait that implements the [Visitor pattern](https://en.wikipedia.org/wiki/Visitor_pattern)
 /// for a depth first walk on [Expr] AST. [`pre_visit`](ExprVisitor::pre_visit) is called
@@ -124,16 +123,13 @@ pub fn walk_expr_mut<V: ExprVisitorMut>(
         Expr::Paren(ParenExpr { expr }) => walk_expr_mut(visitor, expr)?,
         Expr::Subquery(SubqueryExpr { expr, .. }) => walk_expr_mut(visitor, expr)?,
         Expr::Extension(Extension { expr }) => {
-            // We can only safely traverse and mutate the extension's children
-            // if this is the only reference to the Arc. Otherwise, we safely
-            // fall back to treating it as a leaf node.
-            if let Some(ext_expr) = Arc::get_mut(expr) {
-                for child in ext_expr.children_mut() {
-                    if !walk_expr_mut(visitor, child)? {
-                        return Ok(false);
-                    }
+            let mut children = expr.children().to_vec();
+            for child in &mut children {
+                if !walk_expr_mut(visitor, child)? {
+                    return Ok(false);
                 }
             }
+            *expr = expr.with_new_children(children);
             true
         }
         Expr::Call(call) => {
@@ -169,6 +165,7 @@ mod tests {
     use crate::parser::ast::ExtensionExpr;
     use crate::parser::value::ValueType;
     use crate::parser::VectorSelector;
+    use std::sync::Arc;
 
     struct NamespaceVisitor {
         namespace: String,
@@ -429,53 +426,20 @@ mod tests {
         fn children(&self) -> &[Expr] {
             &self.children
         }
-        fn children_mut(&mut self) -> &mut [Expr] {
-            &mut self.children
+        fn with_new_children(&self, children: Vec<Expr>) -> Arc<dyn ExtensionExpr> {
+            Arc::new(DummyExtension { children })
         }
     }
 
     #[test]
-    fn test_inject_label_into_unshared_extension() {
-        let inner_expr = parser::parse("pg_stat_activity_count{}").unwrap();
-        let dummy_ext = DummyExtension {
-            children: vec![inner_expr],
-        };
-
-        let unique_arc = std::sync::Arc::new(dummy_ext);
-
-        let mut ast = Expr::Extension(parser::Extension { expr: unique_arc });
-
-        let mut visitor = LabelInjectorVisitor {
-            label_name: "env".to_string(),
-            label_value: "prod".to_string(),
-        };
-        assert!(walk_expr_mut(&mut visitor, &mut ast).unwrap());
-
-        // Because the Arc was uniquely owned, `get_mut` succeeded, the extension's
-        // children were traversed, and the inner selector was mutated.
-        if let Expr::Extension(ext) = &ast {
-            let children = ext.expr.children();
-            assert_eq!(children.len(), 1);
-            if let Expr::VectorSelector(vs) = &children[0] {
-                assert_eq!(vs.matchers.matchers.len(), 1);
-                assert_eq!(vs.matchers.matchers[0].name, "env");
-                assert_eq!(vs.matchers.matchers[0].value, "prod");
-            } else {
-                panic!("expected inner expression to be a VectorSelector");
-            }
-        } else {
-            panic!("expected Extension expression");
-        }
-    }
-
-    #[test]
-    fn test_skip_shared_extension() {
+    fn test_inject_label_into_extension() {
         let inner_expr = parser::parse("pg_stat_activity_count{}").unwrap();
         let dummy_ext = DummyExtension {
             children: vec![inner_expr],
         };
 
         let shared_arc = std::sync::Arc::new(dummy_ext);
+        // Clone the Arc to simulate multiple references to the same extension expression.
         let _second_reference = std::sync::Arc::clone(&shared_arc);
 
         let mut ast = Expr::Extension(parser::Extension { expr: shared_arc });
@@ -486,16 +450,14 @@ mod tests {
         };
         assert!(walk_expr_mut(&mut visitor, &mut ast).unwrap());
 
-        // Because the Arc was shared, `get_mut` failed, the extension was
-        // treated as a leaf node, and the inner selector was NOT mutated.
+        // The extension's children should be traversed and mutated like any other expression.
         if let Expr::Extension(ext) = &ast {
             let children = ext.expr.children();
             assert_eq!(children.len(), 1);
             if let Expr::VectorSelector(vs) = &children[0] {
-                assert!(
-                    vs.matchers.matchers.is_empty(),
-                    "inner VectorSelector should not have been mutated"
-                );
+                assert_eq!(vs.matchers.matchers.len(), 1);
+                assert_eq!(vs.matchers.matchers[0].name, "env");
+                assert_eq!(vs.matchers.matchers[0].value, "prod");
             } else {
                 panic!("expected inner expression to be a VectorSelector");
             }

--- a/src/util/visitor.rs
+++ b/src/util/visitor.rs
@@ -15,6 +15,7 @@
 use crate::parser::{
     AggregateExpr, BinaryExpr, Expr, Extension, ParenExpr, SubqueryExpr, UnaryExpr,
 };
+use std::sync::Arc;
 
 /// Trait that implements the [Visitor pattern](https://en.wikipedia.org/wiki/Visitor_pattern)
 /// for a depth first walk on [Expr] AST. [`pre_visit`](ExprVisitor::pre_visit) is called
@@ -30,6 +31,24 @@ pub trait ExprVisitor {
     /// Called after all children are visited. Return `Ok(false)` to cut short the recursion
     /// (skip traversing and return).
     fn post_visit(&mut self, _plan: &Expr) -> Result<bool, Self::Error> {
+        Ok(true)
+    }
+}
+
+/// Trait that implements the [Visitor pattern](https://en.wikipedia.org/wiki/Visitor_pattern)
+/// for a depth first walk on [Expr] AST. [`pre_visit`](ExprVisitorMut::pre_visit) is called
+/// before any children are visited, and then [`post_visit`](ExprVisitorMut::post_visit) is called
+/// after all children have been visited. Only [`pre_visit`](ExprVisitorMut::pre_visit) is required.
+pub trait ExprVisitorMut {
+    type Error;
+
+    /// Called before any children are visited. Return `Ok(false)` to cut short the recursion
+    /// (skip traversing and return).
+    fn pre_visit(&mut self, plan: &mut Expr) -> Result<bool, Self::Error>;
+
+    /// Called after all children are visited. Return `Ok(false)` to cut short the recursion
+    /// (skip traversing and return).
+    fn post_visit(&mut self, _plan: &mut Expr) -> Result<bool, Self::Error> {
         Ok(true)
     }
 }
@@ -84,11 +103,71 @@ pub fn walk_expr<V: ExprVisitor>(visitor: &mut V, expr: &Expr) -> Result<bool, V
     Ok(true)
 }
 
+/// A util function that traverses an AST [Expr] mutably in depth-first order.
+/// Returns `Ok(true)` if all nodes were visited, and `Ok(false)` if any call to
+/// [`pre_visit`](ExprVisitorMut::pre_visit) or [`post_visit`](ExprVisitorMut::post_visit)
+/// returned `Ok(false)` and may have cut short the recursion.
+pub fn walk_expr_mut<V: ExprVisitorMut>(
+    visitor: &mut V,
+    expr: &mut Expr,
+) -> Result<bool, V::Error> {
+    if !visitor.pre_visit(expr)? {
+        return Ok(false);
+    }
+
+    let recurse = match expr {
+        Expr::Aggregate(AggregateExpr { expr, .. }) => walk_expr_mut(visitor, expr)?,
+        Expr::Unary(UnaryExpr { expr }) => walk_expr_mut(visitor, expr)?,
+        Expr::Binary(BinaryExpr { lhs, rhs, .. }) => {
+            walk_expr_mut(visitor, lhs)? && walk_expr_mut(visitor, rhs)?
+        }
+        Expr::Paren(ParenExpr { expr }) => walk_expr_mut(visitor, expr)?,
+        Expr::Subquery(SubqueryExpr { expr, .. }) => walk_expr_mut(visitor, expr)?,
+        Expr::Extension(Extension { expr }) => {
+            // We can only safely traverse and mutate the extension's children
+            // if this is the only reference to the Arc. Otherwise, we safely
+            // fall back to treating it as a leaf node.
+            if let Some(ext_expr) = Arc::get_mut(expr) {
+                for child in ext_expr.children_mut() {
+                    if !walk_expr_mut(visitor, child)? {
+                        return Ok(false);
+                    }
+                }
+            }
+            true
+        }
+        Expr::Call(call) => {
+            for func_argument_expr in &mut call.args.args {
+                if !walk_expr_mut(visitor, func_argument_expr)? {
+                    return Ok(false);
+                }
+            }
+            true
+        }
+        Expr::NumberLiteral(_)
+        | Expr::StringLiteral(_)
+        | Expr::VectorSelector(_)
+        | Expr::MatrixSelector(_) => true,
+    };
+
+    if !recurse {
+        return Ok(false);
+    }
+
+    if !visitor.post_visit(expr)? {
+        return Ok(false);
+    }
+
+    Ok(true)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::label::MatchOp;
     use crate::parser;
+    use crate::parser::ast::ExtensionExpr;
+    use crate::parser::value::ValueType;
     use crate::parser::VectorSelector;
 
     struct NamespaceVisitor {
@@ -221,7 +300,207 @@ mod tests {
         let ast = parser::parse("1 % pg_stat_activity_count{namespace=\"sample\"}").unwrap();
         assert!(!walk_expr(&mut visitor, &ast).unwrap());
 
-        let ast = parser::parse("pg_stat_activity_count{namespace=\"sample\"} ^ pg_stat_activity_count{namespace=\"sample\"}").unwrap();
+        let ast = parser::parse(
+            "pg_stat_activity_count{namespace=\"sample\"} ^ \
+             pg_stat_activity_count{namespace=\"sample\"}",
+        )
+        .unwrap();
         assert!(walk_expr(&mut visitor, &ast).unwrap());
+    }
+
+    struct LabelInjectorVisitor {
+        label_name: String,
+        label_value: String,
+    }
+
+    impl ExprVisitorMut for LabelInjectorVisitor {
+        type Error = &'static str;
+
+        fn pre_visit(&mut self, expr: &mut Expr) -> Result<bool, Self::Error> {
+            if let Expr::VectorSelector(vector_selector) = expr {
+                vector_selector
+                    .matchers
+                    .matchers
+                    .push(crate::label::Matcher {
+                        op: MatchOp::Equal,
+                        name: self.label_name.clone(),
+                        value: self.label_value.clone(),
+                    });
+            }
+            Ok(true)
+        }
+    }
+
+    #[test]
+    fn test_inject_label_into_vector_selector() {
+        let expr = "pg_stat_activity_count{}";
+        let mut ast = parser::parse(expr).unwrap();
+
+        let mut visitor = LabelInjectorVisitor {
+            label_name: "namespace".to_string(),
+            label_value: "injected".to_string(),
+        };
+
+        assert!(walk_expr_mut(&mut visitor, &mut ast).unwrap());
+
+        if let Expr::VectorSelector(vs) = &ast {
+            assert_eq!(vs.matchers.matchers.len(), 1);
+            assert_eq!(vs.matchers.matchers[0].name, "namespace");
+            assert_eq!(vs.matchers.matchers[0].value, "injected");
+            assert_eq!(vs.matchers.matchers[0].op, MatchOp::Equal);
+        } else {
+            panic!("expected VectorSelector");
+        }
+    }
+
+    #[test]
+    fn test_inject_label_into_nested_expr() {
+        let expr = "sum(pg_stat_activity_count{})";
+        let mut ast = parser::parse(expr).unwrap();
+
+        let mut visitor = LabelInjectorVisitor {
+            label_name: "env".to_string(),
+            label_value: "prod".to_string(),
+        };
+
+        assert!(walk_expr_mut(&mut visitor, &mut ast).unwrap());
+
+        if let Expr::Aggregate(agg) = &ast {
+            if let Expr::VectorSelector(vs) = &*agg.expr {
+                assert_eq!(vs.matchers.matchers.len(), 1);
+                assert_eq!(vs.matchers.matchers[0].name, "env");
+                assert_eq!(vs.matchers.matchers[0].value, "prod");
+            } else {
+                panic!("expected VectorSelector inside Aggregate");
+            }
+        } else {
+            panic!("expected Aggregate");
+        }
+    }
+
+    #[test]
+    fn test_inject_label_into_multiple_selectors() {
+        let expr = "pg_stat_activity_count{} + pg_stat_activity_count{}";
+        let mut ast = parser::parse(expr).unwrap();
+
+        let mut visitor = LabelInjectorVisitor {
+            label_name: "env".to_string(),
+            label_value: "prod".to_string(),
+        };
+
+        assert!(walk_expr_mut(&mut visitor, &mut ast).unwrap());
+
+        if let Expr::Binary(binary) = &ast {
+            if let Expr::VectorSelector(lhs_vs) = &*binary.lhs {
+                assert_eq!(lhs_vs.matchers.matchers.len(), 1);
+                assert_eq!(lhs_vs.matchers.matchers[0].name, "env");
+                assert_eq!(lhs_vs.matchers.matchers[0].value, "prod");
+            } else {
+                panic!("expected LHS to be a VectorSelector");
+            }
+
+            if let Expr::VectorSelector(rhs_vs) = &*binary.rhs {
+                assert_eq!(rhs_vs.matchers.matchers.len(), 1);
+                assert_eq!(rhs_vs.matchers.matchers[0].name, "env");
+                assert_eq!(rhs_vs.matchers.matchers[0].value, "prod");
+            } else {
+                panic!("expected RHS to be a VectorSelector");
+            }
+        } else {
+            panic!("expected a Binary expression");
+        }
+    }
+
+    #[derive(Debug)]
+    struct DummyExtension {
+        children: Vec<Expr>,
+    }
+
+    impl ExtensionExpr for DummyExtension {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+        fn name(&self) -> &str {
+            "dummy"
+        }
+        fn value_type(&self) -> ValueType {
+            ValueType::Vector
+        }
+        fn children(&self) -> &[Expr] {
+            &self.children
+        }
+        fn children_mut(&mut self) -> &mut [Expr] {
+            &mut self.children
+        }
+    }
+
+    #[test]
+    fn test_inject_label_into_unshared_extension() {
+        let inner_expr = parser::parse("pg_stat_activity_count{}").unwrap();
+        let dummy_ext = DummyExtension {
+            children: vec![inner_expr],
+        };
+
+        let unique_arc = std::sync::Arc::new(dummy_ext);
+
+        let mut ast = Expr::Extension(parser::Extension { expr: unique_arc });
+
+        let mut visitor = LabelInjectorVisitor {
+            label_name: "env".to_string(),
+            label_value: "prod".to_string(),
+        };
+        assert!(walk_expr_mut(&mut visitor, &mut ast).unwrap());
+
+        // Because the Arc was uniquely owned, `get_mut` succeeded, the extension's
+        // children were traversed, and the inner selector was mutated.
+        if let Expr::Extension(ext) = &ast {
+            let children = ext.expr.children();
+            assert_eq!(children.len(), 1);
+            if let Expr::VectorSelector(vs) = &children[0] {
+                assert_eq!(vs.matchers.matchers.len(), 1);
+                assert_eq!(vs.matchers.matchers[0].name, "env");
+                assert_eq!(vs.matchers.matchers[0].value, "prod");
+            } else {
+                panic!("expected inner expression to be a VectorSelector");
+            }
+        } else {
+            panic!("expected Extension expression");
+        }
+    }
+
+    #[test]
+    fn test_skip_shared_extension() {
+        let inner_expr = parser::parse("pg_stat_activity_count{}").unwrap();
+        let dummy_ext = DummyExtension {
+            children: vec![inner_expr],
+        };
+
+        let shared_arc = std::sync::Arc::new(dummy_ext);
+        let _second_reference = std::sync::Arc::clone(&shared_arc);
+
+        let mut ast = Expr::Extension(parser::Extension { expr: shared_arc });
+
+        let mut visitor = LabelInjectorVisitor {
+            label_name: "env".to_string(),
+            label_value: "prod".to_string(),
+        };
+        assert!(walk_expr_mut(&mut visitor, &mut ast).unwrap());
+
+        // Because the Arc was shared, `get_mut` failed, the extension was
+        // treated as a leaf node, and the inner selector was NOT mutated.
+        if let Expr::Extension(ext) = &ast {
+            let children = ext.expr.children();
+            assert_eq!(children.len(), 1);
+            if let Expr::VectorSelector(vs) = &children[0] {
+                assert!(
+                    vs.matchers.matchers.is_empty(),
+                    "inner VectorSelector should not have been mutated"
+                );
+            } else {
+                panic!("expected inner expression to be a VectorSelector");
+            }
+        } else {
+            panic!("expected Extension expression");
+        }
     }
 }


### PR DESCRIPTION
Partially addresses #137 

This PR implements the mutable version of the AST visitor (`ExprVisitorMut` and `walk_expr_mut`) to allow in-place mutations of the AST.

To support mutating extension nodes, I added `children_mut()` to the `ExtensionExpr` trait. Because the extension holds the inner expression in an `Arc<dyn ExtensionExpr>`, `walk_expr_mut` attempts to unwrap it using `Arc::get_mut`. Currently, if `Arc::get_mut` fails (meaning there are multiple references to the shared `Arc`), the walker falls back to treating the extension as a leaf node and skips traversing its children.

I'm not entirely sure if this fallback behavior is the most reasonable approach. I would love to hear your thoughts on whether we should keep it this way, or perhaps delegate the decision to the visitor itself (e.g., by adding an optional `visit_shared_extension` method to the `ExprVisitorMut` trait so implementers can choose whether to skip, halt, or throw a custom error).

As discussed in the issue, I implemented this manually without using macros for now. I realized it would be more complicated than expected to use a macro to deduplicate the code, since `Expr::Extension` must be handled differently depending on whether it is immutable or mutable.