### PR TITLE
feat: Add Prometheus min_of and max_of functions

### DIFF
--- a/src/parser/function.rs
+++ b/src/parser/function.rs
@@ -386,11 +386,25 @@ lazy_static! {
             false
         ),
         function!(
+            "max_of",
+            vec![ValueType::Scalar, ValueType::Scalar],
+            0,
+            ValueType::Scalar,
+            true
+        ),
+        function!(
             "last_over_time",
             vec![ValueType::Matrix],
             0,
             ValueType::Vector,
             false
+        ),
+        function!(
+            "min_of",
+            vec![ValueType::Scalar, ValueType::Scalar],
+            0,
+            ValueType::Scalar,
+            true
         ),
         function!("ln", vec![ValueType::Vector], 0, ValueType::Vector, false),
         function!(
@@ -654,5 +668,13 @@ mod tests {
         let rate = get_function("rate").unwrap();
         assert_eq!(rate.variadic, 0);
         assert!(!rate.experimental);
+
+        for func_name in ["max_of", "min_of"] {
+            let func = get_function(func_name).unwrap();
+            assert_eq!(func.arg_types, vec![ValueType::Scalar, ValueType::Scalar]);
+            assert_eq!(func.variadic, 0);
+            assert_eq!(func.return_type, ValueType::Scalar);
+            assert!(func.experimental);
+        }
     }
 }

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -1356,6 +1356,18 @@ mod tests {
                     FunctionArgs::new_args(ex).append_args(Expr::from(5.0)),
                 )
             }),
+            ("max_of(1, 2)", {
+                Expr::new_call(
+                    get_function("max_of").unwrap(),
+                    FunctionArgs::new_args(Expr::from(1.0)).append_args(Expr::from(2.0)),
+                )
+            }),
+            ("min_of(1, 2)", {
+                Expr::new_call(
+                    get_function("min_of").unwrap(),
+                    FunctionArgs::new_args(Expr::from(1.0)).append_args(Expr::from(2.0)),
+                )
+            }),
             ("double_exponential_smoothing(some_metric[5m], 0.5, 0.1)", {
                 Expr::new_matrix_selector(
                     Expr::from(VectorSelector::from("some_metric")),


### PR DESCRIPTION
### Motivation
- Bring Rust function metadata into parity with Prometheus by adding the missing scalar functions reported by the comparison script.
- Ensure the parser recognizes scalar calls to these experimental functions and that metadata assertions cover them.

### Description
- Add `max_of` and `min_of` entries to the function registry in `src/parser/function.rs` with `vec![ValueType::Scalar, ValueType::Scalar]`, `variadic = 0`, `return_type = ValueType::Scalar`, and `experimental = true`.
- Add metadata assertions in the `tests` module in `src/parser/function.rs` to validate argument types, arity, return type, and experimental flag for both functions.
- Add parser test coverage in `src/parser/parse.rs` for `"max_of(1, 2)"` and `"min_of(1, 2)"` to exercise parsing of scalar function calls.

### Testing
- Ran `python scripts/compare_functions.py` and it reported parity: Go functions = 89, Rust functions = 89, Missing = 0 (passed).
- Ran `cargo test` and all unit tests and doc-tests passed (`119` unit tests passed, doc-tests passed).
- Ran `cargo fmt -- --check` which succeeded (formatting consistent).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2675c1c03483298254171f0e0e1769)